### PR TITLE
fix: run Allure report on all CI events

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -303,12 +303,12 @@ jobs:
   # (simple-elf base image removed; step-security fork adds unwanted abstractions).
   # History is preserved across runs for trend graphs.
   # A PR comment is posted with a direct link to the published report.
-  # Only runs on push (merge to main/feature branch), not on PR events.
+  # Runs on both push and PR events so every run gets a report.
   # ---------------------------------------------------------------------------
   allure-report:
     name: Publish Allure report
     needs: bowser-test
-    if: always() && github.event_name == 'push'
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       contents: write        # needed to push to gh-pages


### PR DESCRIPTION
## Summary
- Remove `github.event_name == 'push'` condition from `allure-report` job
- Allure report now publishes on both push and pull_request events

## Test plan
- [ ] Verify Allure report job runs (not skipped) on PR events
- [ ] Verify report still publishes to gh-pages

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed the `github.event_name == 'push'` condition from the `allure-report` job, enabling test reports to be generated and published for both push and pull request events.

**Key changes:**
- Updated job condition from `if: always() && github.event_name == 'push'` to `if: always()` 
- Updated documentation comment to reflect new behavior
- PR comment step already correctly guarded with `if: github.event_name == 'pull_request'`

**Benefits:**
- Pull requests now get Allure test reports with trend graphs
- Better visibility into test results during PR review
- Consistent reporting across both push and PR workflows

**No issues found** - the implementation is correct and all necessary permissions are already in place.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - simple configuration change with clear benefits and no breaking changes
- The change removes a single condition from a job's if statement, enabling Allure test reports on PR events in addition to push events. The implementation is correct: permissions are already in place, the PR comment step is properly guarded, and the `always()` condition ensures reports are generated even when tests fail. No new race conditions are introduced (concurrent gh-pages pushes already possible with bowser-weekly workflow)
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/preview-deploy.yml | Removed push-only restriction from `allure-report` job so it now runs on both push and PR events, enabling test reports for all workflow runs |

</details>



<sub>Last reviewed commit: 2995764</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->