### PR TITLE
feat: OpenAPI full coverage — 24 endpoints via chanfana

### DIFF
--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -164,7 +164,6 @@ openapi.post('/api/quiz/check', QuizCheckEndpoint);
 openapi.get('/api/health/metrics', MetricsEndpoint);
 openapi.get('/api/share/:id', ShareEndpoint);
 
-
 // Admin feature flag routes
 app.route('/', adminFlags);
 

--- a/src/worker/routes/openapi-alerts.ts
+++ b/src/worker/routes/openapi-alerts.ts
@@ -81,13 +81,13 @@ export class AlertsEndpoint extends OpenAPIRoute {
 }
 
 const EmergingCampaignSchema = z.object({
-  id: z.string(),
-  scam_type: z.string(),
   domain: z.string().optional(),
+  scam_type: z.string(),
   report_count: z.number(),
-  confidence: z.number(),
-  first_detected: z.number(),
-  last_seen: z.number(),
+  first_seen: z.string(),
+  last_seen: z.string(),
+  source: z.literal('community'),
+  status: z.literal('investigating'),
 });
 
 const AlertsEmergingResponseSchema = z.object({


### PR DESCRIPTION
## Summary

- Wire all 24 public API endpoints into chanfana's `fromHono()` wrapper so they appear in the auto-generated `/openapi.json` and `/docs` Swagger UI
- Add `AlertsEmergingEndpoint` and `AlertsBySlugEndpoint` to `openapi-alerts.ts` (these endpoints existed in the Hono router but had no chanfana class)
- All endpoints have full Zod schemas for request params, query, body, and responses

## Endpoints now documented

| Method | Path | Tag |
|--------|------|-----|
| POST | /api/check | Analysis |
| POST | /api/check/image | Analysis |
| POST | /api/check-qr | Analysis |
| GET | /api/alerts | Alerts |
| GET | /api/alerts/emerging | Alerts |
| GET | /api/alerts/:slug | Alerts |
| GET | /health | System |
| GET | /health/deep | System |
| GET | /api/counter | Statistics |
| GET | /api/reports | Community |
| POST | /api/reports/:id/vote | Community |
| GET | /api/feed/latest | Feed |
| GET | /api/stats | Statistics |
| GET | /api/badges | Statistics |
| GET | /api/digest/latest | Digest |
| POST | /api/digest/subscribe | Digest |
| POST | /api/digest/unsubscribe | Digest |
| POST | /api/newsletter/subscribe | Newsletter |
| POST | /api/newsletter/unsubscribe | Newsletter |
| POST | /api/translation-report | Feedback |
| GET | /api/quiz | Quiz |
| POST | /api/quiz/check | Quiz |
| GET | /api/health/metrics | System |
| GET | /api/share/:id | Share |

## Test plan

- [x] `npx tsc --noEmit` — passes clean
- [x] `npx vitest run` — 1087/1087 tests pass
- [ ] Verify `/openapi.json` returns valid spec with all 24 paths
- [ ] Verify `/docs` renders Swagger UI with all endpoints visible

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully adds OpenAPI documentation coverage for all 24 public API endpoints by wiring them through chanfana's `fromHono()` wrapper. The two new endpoint classes (`AlertsEmergingEndpoint` and `AlertsBySlugEndpoint`) were added to complete the alerts API coverage.

**Key changes:**
- Added `AlertsEmergingEndpoint` and `AlertsBySlugEndpoint` classes with full Zod schemas
- Registered all 24 endpoints in `index.ts` in the correct order (specific routes before parameterized ones)
- Previous schema mismatch issues have been corrected

**Observations:**
- `AlertsEmergingEndpoint` implements rate limiting but doesn't document the `429` error response in its OpenAPI schema. While the code functions correctly, adding this to the schema would improve API documentation completeness (similar to how `CheckEndpoint` and other POST endpoints document their rate limit responses)
- Error handling uses silent catch blocks, which is consistent with the existing codebase pattern

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no blocking issues
- All 24 endpoints are correctly registered with proper schemas matching actual types. Previous schema mismatch and formatting issues have been fixed. Tests pass (1087/1087). The only observations are minor OpenAPI documentation completeness items that don't affect functionality.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/worker/index.ts | Imports two new alert endpoint classes and registers them in the correct order (specific routes before parameterized routes) |
| src/worker/routes/openapi-alerts.ts | Adds `AlertsEmergingEndpoint` and `AlertsBySlugEndpoint` with correct Zod schemas matching actual types, includes rate limiting and error handling |

</details>



<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fworker%2Froutes%2Fopenapi-alerts.ts%3A113-118%0AConsider%20documenting%20the%20%60'429'%60%20response%20since%20rate%20limiting%20is%20implemented%20%28lines%20123-129%29%0A%0A&repo=zenprocess%2Faigrija"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<sub>Last reviewed commit: d06cc77</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->