### PR TITLE
feat: CF Dashboard custom error pages for edge-level errors

### DIFF
--- a/infra/index.ts
+++ b/infra/index.ts
@@ -215,6 +215,25 @@ for (const { configKey, secretName } of secretDefs) {
 }
 
 // ---------------------------------------------------------------------------
+// CF Custom Error Pages — served from R2 CDN for edge-level 500 and 1000 errors
+// ---------------------------------------------------------------------------
+const cfErrorPageUrl = "https://cdn.ai-grija.ro/cf-error.html";
+
+new cloudflare.CustomPages("custom-error-500", {
+  zoneId,
+  type: "500Errors",
+  url: cfErrorPageUrl,
+  state: "customized",
+});
+
+new cloudflare.CustomPages("custom-error-1000", {
+  zoneId,
+  type: "1000Errors",
+  url: cfErrorPageUrl,
+  state: "customized",
+});
+
+// ---------------------------------------------------------------------------
 // Stack Outputs
 // ---------------------------------------------------------------------------
 export const kvNamespaceId = kvNamespace.id;

--- a/scripts/upload-cf-error-page.sh
+++ b/scripts/upload-cf-error-page.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npx wrangler r2 object put ai-grija-cdn/cf-error.html \
+  --file src/static/cf-error.html \
+  --content-type "text/html;charset=UTF-8" \
+  --cache-control "public, max-age=300"

--- a/src/static/cf-error.html
+++ b/src/static/cf-error.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="ro">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="refresh" content="15" />
+  <title>Eroare temporara — ai-grija.ro</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      background-color: #0f172a;
+      color: #e2e8f0;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem 1rem;
+    }
+    .card {
+      background-color: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 1rem;
+      max-width: 520px;
+      width: 100%;
+      padding: 2.5rem 2rem;
+      text-align: center;
+      box-shadow: 0 25px 50px -12px rgba(0,0,0,0.5);
+    }
+    .icon { display: flex; justify-content: center; margin-bottom: 1.5rem; }
+    .icon svg { width: 64px; height: 64px; color: #22c55e; }
+    .brand {
+      display: inline-flex; align-items: center; gap: 0.4rem;
+      font-size: 1.125rem; font-weight: 700; color: #22c55e;
+      text-decoration: none; margin-bottom: 1.5rem;
+    }
+    .brand-dot { width: 8px; height: 8px; background-color: #22c55e; border-radius: 50%; display: inline-block; }
+    h1 { font-size: 1.5rem; font-weight: 700; color: #f1f5f9; margin-bottom: 0.75rem; line-height: 1.3; }
+    p.subtitle { font-size: 0.9375rem; color: #94a3b8; line-height: 1.6; margin-bottom: 1.75rem; }
+    .refresh-note { font-size: 0.8125rem; color: #64748b; margin-bottom: 1.5rem; }
+    .refresh-note span { color: #22c55e; font-weight: 600; }
+    .btn {
+      display: inline-block; background-color: #22c55e; color: #0f172a;
+      font-weight: 700; font-size: 0.9375rem; padding: 0.625rem 1.75rem;
+      border-radius: 0.5rem; text-decoration: none; border: none; cursor: pointer;
+    }
+    .btn:hover { background-color: #16a34a; }
+    .cf-error-box {
+      margin-top: 1.5rem; padding: 1rem; background-color: #0f172a;
+      border: 1px solid #334155; border-radius: 0.5rem; font-size: 0.75rem;
+      color: #64748b; text-align: left; word-break: break-word;
+    }
+    .cf-error-box:empty { display: none; }
+    footer { margin-top: 2.5rem; font-size: 0.75rem; color: #475569; }
+    footer a { color: #22c55e; text-decoration: none; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">
+      <svg viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+        <circle cx="32" cy="32" r="30" stroke="currentColor" stroke-width="3"/>
+        <circle cx="22" cy="25" r="3" fill="currentColor"/>
+        <circle cx="42" cy="25" r="3" fill="currentColor"/>
+        <path d="M20 44 Q32 36 44 44" stroke="currentColor" stroke-width="3" stroke-linecap="round" fill="none"/>
+      </svg>
+    </div>
+    <a class="brand" href="https://ai-grija.ro"><span class="brand-dot"></span>ai-grija.ro</a>
+    <h1>Serviciul este temporar indisponibil</h1>
+    <p class="subtitle">Platforma de prevenire a fraudelor AI este momentan inaccesibila. Echipa noastra a fost notificata si lucreaza la rezolvarea problemei.</p>
+    <p class="refresh-note">Pagina se va reincarca automat in <span>15 secunde</span>.</p>
+    <a class="btn" href="/">Incearca din nou</a>
+    <div class="cf-error-box">::CLOUDFLARE_ERROR_500S_BOX::</div>
+    <div class="cf-error-box">::CLOUDFLARE_ERROR_1000S_BOX::</div>
+  </div>
+  <footer>&copy; 2026 <a href="https://ai-grija.ro">ai-grija.ro</a> &mdash; Protectie impotriva fraudelor online</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `src/static/cf-error.html`: a self-contained branded error page for Cloudflare edge-level errors — dark theme (#0f172a bg, #22c55e green accent), Romanian copy ("Serviciul este temporar indisponibil"), inline SVG sad-face icon, 15s auto-refresh, and CF template variable placeholders `::CLOUDFLARE_ERROR_500S_BOX::` / `::CLOUDFLARE_ERROR_1000S_BOX::`.
- Adds `scripts/upload-cf-error-page.sh` to upload the page to the `ai-grija-cdn` R2 bucket via wrangler.
- Extends `infra/index.ts` with two `cloudflare.CustomPages` Pulumi resources (`500Errors` and `1000Errors`) pointing to `https://cdn.ai-grija.ro/cf-error.html`.

Recreates the work from issue #261 that was lost when PR #280 was closed.

## Test plan

- [ ] Upload the page manually: `bash scripts/upload-cf-error-page.sh`
- [ ] Verify the file is reachable at `https://cdn.ai-grija.ro/cf-error.html`
- [ ] Run `pulumi preview` in `infra/` — confirm two `CustomPages` resources are planned
- [ ] Trigger a 5xx from the origin and confirm the branded error page is served
- [ ] Confirm `npx tsc --noEmit` passes (CI gate)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Cloudflare custom error pages for edge-level 500/1000 errors with a branded Romanian error page served from R2 CDN. The HTML is well-crafted with proper accessibility, auto-refresh, and CF template variables. However, the implementation has critical infrastructure gaps:

- The `ai-grija-cdn` R2 bucket referenced in the upload script is not provisioned in `infra/index.ts`
- The `cdn.ai-grija.ro` DNS record is missing — no `cloudflare.Record` resource exists for this subdomain
- The CustomPages resources will fail at runtime because the URL they point to won't resolve

To fix: add the R2 bucket resource to Pulumi (similar to `ai-grija-share-cards`), add a DNS CNAME record for `cdn.ai-grija.ro`, and configure R2 custom domain in the Cloudflare dashboard per ADR-0016.

<h3>Confidence Score: 1/5</h3>

- This PR will fail to work as the required infrastructure (R2 bucket and DNS) is not provisioned
- Score reflects critical missing dependencies: the `ai-grija-cdn` bucket doesn't exist in Pulumi, `cdn.ai-grija.ro` DNS is not configured, and the CustomPages will point to a non-resolvable URL. The upload script will fail, and even if run manually, the error pages won't be served correctly.
- `infra/index.ts` and `scripts/upload-cf-error-page.sh` need the missing infrastructure before this can work

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/upload-cf-error-page.sh | Upload script for error page; references non-existent `ai-grija-cdn` bucket |
| infra/index.ts | Adds CustomPages config for CF errors; missing R2 bucket and DNS record for cdn subdomain |
| src/static/cf-error.html | Self-contained branded error page with Romanian copy and CF template variables; looks good |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User Request] --> B{CF Edge}
    B -->|Origin Error 500/1000| C[CustomPages Lookup]
    C --> D[Fetch from cdn.ai-grija.ro/cf-error.html]
    D --> E{DNS Resolution}
    E -->|Missing DNS!| F[Error: DNS not configured]
    E -->|Resolved| G[R2 Bucket ai-grija-cdn]
    G -->|Missing Bucket!| H[Error: Bucket not provisioned]
    G -->|Found| I[Return cf-error.html]
    I --> J[Inject CF Variables]
    J --> K[Serve Branded Error Page]
    B -->|Success| L[Origin Response]
    
    style F fill:#ff6b6b
    style H fill:#ff6b6b
    style C fill:#22c55e
    style K fill:#22c55e
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ascripts%2Fupload-cf-error-page.sh%3A4%0A%60ai-grija-cdn%60%20bucket%20not%20defined%20in%20%60infra%2Findex.ts%60%20%E2%80%94%20the%20infrastructure%20only%20provisions%20%60ai-grija-share-cards%60%2C%20%60ai-grija-share-cards-preview%60%2C%20and%20%60ai-grija-pulumi-state%60.%20Either%20add%20the%20bucket%20to%20Pulumi%20or%20use%20an%20existing%20bucket.%0A%0A%23%23%23%20Issue%202%20of%203%0Ainfra%2Findex.ts%3A220%0A%60cdn.ai-grija.ro%60%20DNS%20record%20not%20defined%20in%20infrastructure%20%E2%80%94%20need%20to%20add%20a%20%60cloudflare.Record%60%20resource%20pointing%20to%20the%20R2%20bucket's%20public%20URL%20%28similar%20to%20%60dns-root%60%20on%20line%2079%29.%0A%0A%23%23%23%20Issue%203%20of%203%0Ainfra%2Findex.ts%3A217-234%0AMissing%20R2%20bucket%20definition%20for%20%60ai-grija-cdn%60%20%E2%80%94%20this%20section%20references%20%60cdn.ai-grija.ro%60%20but%20the%20bucket%20isn't%20provisioned.%20Add%20a%20%60cloudflare.R2Bucket%60%20resource%20%28like%20%60r2Bucket%60%20on%20line%2043%29%20and%20configure%20R2%20custom%20domain%20in%20the%20Cloudflare%20dashboard.%0A%0A&repo=zenprocess%2Faigrija"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<sub>Last reviewed commit: 105e367</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->