### PR TITLE
fix: CF Access JWT verification using JWK import

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -12,7 +12,7 @@
   <link rel="icon" type="image/x-icon" href="/favicon.ico" />
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
   <link rel="manifest" href="/assets/manifest-DPT5v3GA.json" />
-  <meta name="theme-color" content="#3b82f6" />
+  <meta name="theme-color" content="#22c55e" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <meta name="apple-mobile-web-app-title" content="ai-grija.ro" />
@@ -28,8 +28,8 @@
 
   <!-- Umami Analytics -->
   <script defer src="https://cloud.umami.is/script.js" data-website-id="da9f42d8-48a1-4326-bef7-64c0b7eaab25"></script>
-  <script type="module" crossorigin src="/assets/index-DslcSsiz.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-DtMFNOV4.css">
+  <script type="module" crossorigin src="/assets/index-PhTyZfNc.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-CeaGahna.css">
 </head>
 <body>
   <div id="root"></div>

--- a/src/ui/public/favicon.svg
+++ b/src/ui/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>

--- a/src/ui/src/App.jsx
+++ b/src/ui/src/App.jsx
@@ -19,7 +19,7 @@ function LoadingSkeleton() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-950">
       <div className="flex flex-col items-center gap-4">
-        <div className="w-10 h-10 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+        <div className="w-10 h-10 border-4 border-green-500 border-t-transparent rounded-full animate-spin" />
         <p className="text-gray-400 text-sm font-mono">Se incarca...</p>
       </div>
     </div>
@@ -33,7 +33,7 @@ const CONTENT_CATEGORIES = ['amenintari', 'ghid', 'educatie', 'povesti', 'rapoar
 function PageShell({ children }) {
   return (
     <ErrorBoundary>
-      <div className="min-h-screen flex flex-col relative selection:bg-blue-500/30 selection:text-white overflow-x-hidden">
+      <div className="min-h-screen flex flex-col relative selection:bg-green-500/30 selection:text-white overflow-x-hidden">
         <div className={`fixed inset-0 bg-[url('${BG_PATTERN}')] opacity-30 pointer-events-none z-0`} />
         <Header />
         <main className="flex-grow">
@@ -102,7 +102,7 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <div className="min-h-screen flex flex-col relative selection:bg-blue-500/30 selection:text-white overflow-x-hidden">
+      <div className="min-h-screen flex flex-col relative selection:bg-green-500/30 selection:text-white overflow-x-hidden">
         <a href="#main-content" className="skip-to-content">Treci la continut principal</a>
         <div className={`fixed inset-0 bg-[url('${BG_PATTERN}')] opacity-30 pointer-events-none z-0`} />
 

--- a/src/ui/src/components/Checker.jsx
+++ b/src/ui/src/components/Checker.jsx
@@ -118,7 +118,7 @@ export default function Checker() {
   };
 
   const handleCopyLink = () => {
-    navigator.clipboard.writeText('https://ai-grija.ro');
+    navigator.clipboard.writeText(buildShareUrl());
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -142,7 +142,7 @@ export default function Checker() {
 
   return (
     <section id="verifica" className="py-20 relative z-20">
-      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         
         <div className="glass-card p-6 md:p-8 relative overflow-hidden group">
           <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGNpcmNsZSBjeD0iMiIgY3k9IjIiIHI9IjEiIGZpbGw9InJnYmEoMjU1LDI1NSwyNTUsMC4wNSkiLz48L3N2Zz4=')] opacity-50"></div>

--- a/src/ui/src/components/ContentList.jsx
+++ b/src/ui/src/components/ContentList.jsx
@@ -25,36 +25,38 @@ export default function ContentList({ category }) {
 
   if (loading) {
     return (
-      <div className="flex justify-center py-16">
-        <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600" data-testid="content-list-spinner" />
+      <div className="flex justify-center py-16 pt-24">
+        <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-green-500" data-testid="content-list-spinner" />
       </div>
     );
   }
 
   if (error) {
-    return <p className="text-center text-red-500 py-8">{error}</p>;
+    return <p className="text-center text-red-500 py-8 pt-24">{error}</p>;
   }
 
   if (items.length === 0) {
-    return <p className="text-center text-gray-500 py-8">{t('feed.noItems')}</p>;
+    return <p className="text-center text-gray-400 py-8 pt-24">{t('feed.noItems')}</p>;
   }
 
   return (
+    <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16">
     <ul className="space-y-4" data-testid="content-list">
       {items.map((item) => (
-        <li key={item.id} className="bg-white rounded-lg shadow p-4">
+        <li key={item.id} className="glass-card p-4 border border-white/10">
           <a
             href={`#/${category}/${item.slug || item.id}`}
-            className="font-semibold text-blue-700 hover:underline"
+            className="font-semibold text-green-400 hover:text-green-300 hover:underline"
             data-testid="content-list-item-link"
           >
             {item.title}
           </a>
           {item.summary && (
-            <p className="text-sm text-gray-600 mt-1">{item.summary}</p>
+            <p className="text-sm text-gray-400 mt-1">{item.summary}</p>
           )}
         </li>
       ))}
     </ul>
+    </div>
   );
 }

--- a/src/ui/src/components/Footer.jsx
+++ b/src/ui/src/components/Footer.jsx
@@ -179,7 +179,7 @@ export default function Footer() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex flex-col md:flex-row justify-between items-start gap-8 mb-8">
           <div className="flex items-center gap-2">
-            <span className="text-xl font-bold tracking-tight text-white">ai-grija<span className="text-blue-500">.ro</span></span>
+            <span className="text-xl font-bold tracking-tight text-white">ai-grija<span className="text-green-500">.ro</span></span>
           </div>
 
           <div className="flex flex-wrap gap-x-8 gap-y-3 text-sm text-gray-400">
@@ -221,7 +221,7 @@ export default function Footer() {
               {t('footer.report_translation')}
             </button>
 
-            <a data-testid="footer-link-github" href="https://github.com/zenprocess/aigrija" target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 hover:text-white transition-colors">
+            <a data-testid="footer-link-github" href="https://github.com/zenprocess/aigrija/discussions/categories/q-a" target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 hover:text-white transition-colors">
               <Github className="w-4 h-4" />
               <span>{t('footer.github')}</span>
             </a>

--- a/src/ui/src/components/Header.jsx
+++ b/src/ui/src/components/Header.jsx
@@ -44,10 +44,10 @@ export default function Header() {
         <div className="flex justify-between items-center h-16">
           {/* Logo */}
           <div className="flex items-center gap-2 cursor-pointer" onClick={() => { window.location.hash = ''; window.scrollTo({ top: 0, behavior: 'smooth' }); }}>
-            <div className="p-1.5 bg-blue-600/20 rounded-lg border border-blue-500/30">
-              <ShieldCheck className="w-6 h-6 text-blue-500" />
+            <div className="p-1.5 bg-green-600/20 rounded-lg border border-green-500/30">
+              <ShieldCheck className="w-6 h-6 text-green-500" />
             </div>
-            <span className="text-xl font-bold tracking-tight text-white">ai-grija<span className="text-blue-500">.ro</span></span>
+            <span className="text-xl font-bold tracking-tight text-white">ai-grija<span className="text-green-500">.ro</span></span>
           </div>
 
           {/* Desktop Nav */}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -192,11 +192,31 @@ app.route('/', translationReport);
 app.route('/', newsletter);
 app.route('/', gepa);
 
+// Explicit service worker route — prevents SPA catch-all from serving HTML
+app.get('/sw.js', async (c) => {
+  return c.body(
+    '// Minimal SW for PWA installability\nself.addEventListener("install", () => self.skipWaiting());\nself.addEventListener("activate", (e) => e.waitUntil(self.clients.claim()));\n',
+    200,
+    { 'Content-Type': 'application/javascript', 'Cache-Control': 'public, max-age=0, must-revalidate' }
+  );
+});
+
 // Asset fallback: for any route not matched by Hono, try the ASSETS binding.
 // This is required because run_worker_first = true intercepts all requests before
 // Cloudflare's asset handler, so static files (index.html, JS, CSS, etc.) would
 // otherwise return 404.
 app.notFound(async (c) => {
+  // Don't serve SPA fallback for file-extension requests (prevents /sw.js#/termeni leak)
+  const pathExt = c.req.path.match(/\.\w{2,5}$/);
+  if (pathExt) {
+    const response = await c.env.ASSETS.fetch(c.req.raw);
+    if (response.status !== 404 && !response.headers.get('content-type')?.includes('text/html')) {
+      return response;
+    }
+    // Static file not found — return 404 directly, no SPA fallback
+    const rid = c.get('requestId') || 'unknown';
+    return c.json({ error: { code: 'NOT_FOUND', message: 'Fisierul nu a fost gasit.' }, request_id: rid }, 404);
+  }
   const response = await c.env.ASSETS.fetch(c.req.raw);
   if (response.status !== 404) {
     return response;

--- a/src/worker/routes/openapi-check-image.ts
+++ b/src/worker/routes/openapi-check-image.ts
@@ -138,7 +138,8 @@ export class CheckImageEndpoint extends OpenAPIRoute {
       }
     } catch (err) {
       structuredLog('error', 'vision_model_failed', { error: String(err) });
-      imageAnalysis = 'Analiza vizuala nu a putut fi finalizata. Modelul de viziune nu este disponibil.';
+      imageAnalysis = '';
+      visionVerdict = 'suspicious';
     }
 
     let classification;
@@ -147,7 +148,20 @@ export class CheckImageEndpoint extends OpenAPIRoute {
       if (visionVerdict === 'phishing' && classification.verdict === 'likely_safe') {
         classification = { ...classification, verdict: 'suspicious' as const };
       }
+    } else if (!imageAnalysis) {
+      // Vision failed and no text context — cannot analyze
+      classification = {
+        verdict: 'suspicious' as const,
+        confidence: 0.0,
+        scam_type: 'Analiza indisponibila',
+        red_flags: [] as string[],
+        explanation: 'Analiza vizuala nu este disponibila momentan. Va rugam sa incercati din nou sau sa furnizati textul mesajului.',
+        recommended_actions: ['Incercati din nou mai tarziu', 'Furnizati textul mesajului pentru analiza text'],
+        model_used: VISION_MODEL,
+        ai_disclaimer: 'Analiza generata de AI. Rezultatele sunt orientative si nu constituie consiliere juridica.',
+      };
     } else {
+      // Vision succeeded, no text context — use vision-only classification
       classification = {
         verdict: visionVerdict,
         confidence: visionVerdict === 'phishing' ? 0.85 : visionVerdict === 'suspicious' ? 0.60 : 0.80,


### PR DESCRIPTION
## Summary
- Fixed admin auth JWT verification that was silently failing
- Root cause: code was importing PEM X.509 certificates as SPKI keys via `importKey('spki', ...)`, which doesn't work — certificates contain more than just the public key
- Fix: use the JWK `keys` array from the CF Access certs endpoint with `importKey('jwk', ...)` 

## Test plan
- [ ] Visit admin.ai-grija.ro — should authenticate via CF Access and load
- [ ] `npx vitest run src/worker/lib/admin-auth.test.ts` — 7 tests pass

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes 10 production bugs across UI, routing, and error handling. Key changes include fixing the share link to copy the verdict URL instead of root URL, preventing service worker routing issues by adding explicit `/sw.js` route and blocking SPA fallback for file-extension requests, and improving vision model error handling to return honest `confidence: 0.0` when analysis fails. The PR also completes the blue-to-green branding migration and adds a green shield favicon.

**Major fixes:**
- Share link now correctly copies verdict share URL with parameters
- Service worker `/sw.js` no longer leaks to SPA router via hash fragments
- Vision model gracefully degrades with honest confidence scoring when unavailable
- GitHub footer link updated to discussions Q&A for better support routing
- ContentList dark theme styling fixed (was white cards on dark background)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk — fixes production bugs with focused changes
- Score reflects well-tested bug fixes across multiple production issues. The changes are focused and address real problems (share link, routing, error handling). Minor complexity in service worker routing logic warrants attention but implementation is sound.
- Pay attention to `src/worker/index.ts` — service worker routing logic uses regex pattern that should be monitored in production

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/ui/src/components/Checker.jsx | Fixed share link to copy verdict URL instead of root URL, widened form to max-w-4xl |
| src/worker/index.ts | Added explicit /sw.js route and file-extension check to prevent SPA fallback for static assets |
| src/worker/routes/openapi-check-image.ts | Improved error handling to return honest confidence=0 when vision model fails with no text context |

</details>



<sub>Last reviewed commit: 5d59ae8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->