### PR TITLE
fix: aigrija — 1 stories

### DIFF
--- a/src/worker/__tests__/newsletter.test.ts
+++ b/src/worker/__tests__/newsletter.test.ts
@@ -82,7 +82,7 @@ describe('POST /api/newsletter/subscribe', () => {
       body: JSON.stringify({ email: 'user@example.com' }),
     });
 
-    const res = await app.fetch(req, makeEnv({ [rlKey('newsletter:9.9.9.9', 60)]: '5' }) as any, ctx);
+    const res = await app.fetch(req, makeEnv({ [rlKey('newsletter:9.9.9.9', 120)]: '5' }) as any, ctx);
     expect(res.status).toBe(429);
     const body = await res.json() as { error: { code: string } };
     expect(body.error.code).toBe('RATE_LIMITED');
@@ -162,7 +162,7 @@ describe('POST /api/newsletter/unsubscribe', () => {
       body: JSON.stringify({ email: 'user@example.com' }),
     });
 
-    const res = await app.fetch(req, makeEnv({ [rlKey('newsletter:8.8.8.8', 60)]: '5' }) as any, ctx);
+    const res = await app.fetch(req, makeEnv({ [rlKey('newsletter:8.8.8.8', 120)]: '5' }) as any, ctx);
     expect(res.status).toBe(429);
   });
 });

--- a/src/worker/lib/rate-limiter.test.ts
+++ b/src/worker/lib/rate-limiter.test.ts
@@ -165,6 +165,39 @@ describe("checkRateLimit — fixed-window expiry", () => {
   });
 });
 
+// ── KV TTL minimum 60s ──────────────────────────────────────────────────────
+
+describe("checkRateLimit — KV TTL minimum", () => {
+  it("TTL is never below 60 even when window has < 60s remaining", async () => {
+    const windowSeconds = 120;
+    vi.useFakeTimers();
+    // Set time to 119s into a 120s window — only 1s remaining
+    const slotStart = Math.floor(Date.now() / 1000 / windowSeconds) * windowSeconds;
+    vi.setSystemTime(new Date((slotStart + 119) * 1000));
+
+    const kv = makeKV();
+    await checkRateLimit(kv, "ttl-min-test", 10, windowSeconds);
+    expect(kv._lastTtl).toBe(60);
+  });
+
+  it("degrades gracefully when KV put throws", async () => {
+    const kv = makeKV();
+    kv.get = async () => null;
+    kv.put = async () => { throw new Error("KV unavailable"); };
+    const result = await checkRateLimit(kv, "kv-fail", 5, 3600);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(5);
+  });
+
+  it("degrades gracefully when KV get throws", async () => {
+    const kv = makeKV();
+    kv.get = async () => { throw new Error("KV unavailable"); };
+    const result = await checkRateLimit(kv, "kv-fail-get", 5, 3600);
+    expect(result.allowed).toBe(true);
+    expect(result.remaining).toBe(5);
+  });
+});
+
 // ── ROUTE_RATE_LIMITS ───────────────────────────────────────────────────────
 
 describe("ROUTE_RATE_LIMITS", () => {
@@ -176,10 +209,10 @@ describe("ROUTE_RATE_LIMITS", () => {
     expect(ROUTE_RATE_LIMITS['vote'].limit).toBeLessThan(ROUTE_RATE_LIMITS['telegram'].limit);
   });
 
-  it("all routes have positive limit and windowSeconds", () => {
+  it("all routes have positive limit and windowSeconds >= 60", () => {
     for (const [route, cfg] of Object.entries(ROUTE_RATE_LIMITS)) {
       expect(cfg.limit, `${route}.limit`).toBeGreaterThan(0);
-      expect(cfg.windowSeconds, `${route}.windowSeconds`).toBeGreaterThan(0);
+      expect(cfg.windowSeconds, `${route}.windowSeconds`).toBeGreaterThanOrEqual(60);
     }
   });
 

--- a/src/worker/lib/rate-limiter.ts
+++ b/src/worker/lib/rate-limiter.ts
@@ -30,12 +30,12 @@ export const ROUTE_RATE_LIMITS: Record<string, RouteRateLimitConfig> = {
   // Counter endpoint — very generous
   'counter':        { limit: 200, windowSeconds: 3600 },
   // Alerts / blog / card / og — read-heavy, generous
-  'alerts':         { limit: 60,  windowSeconds: 60 },
-  'blog':           { limit: 60,  windowSeconds: 60 },
-  'card':           { limit: 60,  windowSeconds: 60 },
-  'og':             { limit: 60,  windowSeconds: 60 },
+  'alerts':         { limit: 60,  windowSeconds: 120 },
+  'blog':           { limit: 60,  windowSeconds: 120 },
+  'card':           { limit: 60,  windowSeconds: 120 },
+  'og':             { limit: 60,  windowSeconds: 120 },
   // RSS feeds — crawlers hammer these; stricter
-  'feed':           { limit: 30,  windowSeconds: 60 },
+  'feed':           { limit: 30,  windowSeconds: 120 },
 };
 
 export interface RateLimitResult {
@@ -74,28 +74,34 @@ export async function checkRateLimit(
   const windowSlot = Math.floor(now / windowSeconds);
   // The window resets at the start of the next slot.
   const reset = (windowSlot + 1) * windowSeconds;
-  // TTL is the remaining time until the window boundary (minimum 1 second).
-  const ttl = Math.max(1, reset - now);
+  // TTL is the remaining time until the window boundary.
+  // Cloudflare KV requires expirationTtl >= 60 seconds.
+  const ttl = Math.max(60, reset - now);
 
   const key = `rl:${identifier}:${windowSlot}`;
 
-  const raw = await cache.get(key);
+  try {
+    const raw = await cache.get(key);
 
-  if (raw === null) {
-    // First request in this window — create key with TTL anchored to window end.
-    await cache.put(key, '1', { expirationTtl: ttl });
-    return { allowed: true, remaining: limit - 1, limit, reset };
+    if (raw === null) {
+      // First request in this window — create key with TTL anchored to window end.
+      await cache.put(key, '1', { expirationTtl: ttl });
+      return { allowed: true, remaining: limit - 1, limit, reset };
+    }
+
+    const current = parseInt(raw, 10);
+    if (current >= limit) {
+      return { allowed: false, remaining: 0, limit, reset };
+    }
+
+    // Increment counter. TTL is re-set to remaining window time so KV expiry
+    // tracks the fixed window boundary, not the time of the last request.
+    await cache.put(key, String(current + 1), { expirationTtl: ttl });
+    return { allowed: true, remaining: limit - current - 1, limit, reset };
+  } catch {
+    // KV failure — degrade gracefully by allowing the request through.
+    return { allowed: true, remaining: limit, limit, reset };
   }
-
-  const current = parseInt(raw, 10);
-  if (current >= limit) {
-    return { allowed: false, remaining: 0, limit, reset };
-  }
-
-  // Increment counter. TTL is re-set to remaining window time so KV expiry
-  // tracks the fixed window boundary, not the time of the last request.
-  await cache.put(key, String(current + 1), { expirationTtl: ttl });
-  return { allowed: true, remaining: limit - current - 1, limit, reset };
 }
 
 /**

--- a/src/worker/routes/newsletter.ts
+++ b/src/worker/routes/newsletter.ts
@@ -24,7 +24,7 @@ newsletter.post('/api/newsletter/subscribe', async (c) => {
     c.req.header('x-real-ip') ||
     'unknown';
 
-  const rl = await checkRateLimit(c.env.CACHE, `newsletter:${ip}`, 5, 60);
+  const rl = await checkRateLimit(c.env.CACHE, `newsletter:${ip}`, 5, 120);
   applyRateLimitHeaders((k, v) => c.header(k, v), rl);
 
   if (!rl.allowed) {
@@ -115,7 +115,7 @@ newsletter.post('/api/newsletter/unsubscribe', async (c) => {
     c.req.header('x-real-ip') ||
     'unknown';
 
-  const rl = await checkRateLimit(c.env.CACHE, `newsletter:${ip}`, 5, 60);
+  const rl = await checkRateLimit(c.env.CACHE, `newsletter:${ip}`, 5, 120);
   applyRateLimitHeaders((k, v) => c.header(k, v), rl);
 
   if (!rl.allowed) {

--- a/src/worker/routes/openapi-newsletter.ts
+++ b/src/worker/routes/openapi-newsletter.ts
@@ -54,7 +54,7 @@ export class NewsletterSubscribeEndpoint extends OpenAPIRoute {
       || c.req.header('x-real-ip')
       || 'unknown';
 
-    const rl = await checkRateLimit(c.env.CACHE, `newsletter:${ip}`, 5, 60);
+    const rl = await checkRateLimit(c.env.CACHE, `newsletter:${ip}`, 5, 120);
     applyRateLimitHeaders((k, v) => c.header(k, v), rl);
 
     if (!rl.allowed) {
@@ -160,7 +160,7 @@ export class NewsletterUnsubscribeEndpoint extends OpenAPIRoute {
       || c.req.header('x-real-ip')
       || 'unknown';
 
-    const rl = await checkRateLimit(c.env.CACHE, `newsletter:${ip}`, 5, 60);
+    const rl = await checkRateLimit(c.env.CACHE, `newsletter:${ip}`, 5, 120);
     applyRateLimitHeaders((k, v) => c.header(k, v), rl);
 
     if (!rl.allowed) {


### PR DESCRIPTION
## Summary

## Test plan
- [x] `npx vitest run` — all tests passed
- [x] `npx tsc --noEmit` — clean
- [ ] Greptile review with zero unresolved comments

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Cloudflare KV constraint — `expirationTtl` must be ≥ 60 seconds — that was silently violated by short-window rate-limit routes. The fix has two parts: raising the TTL floor from 1 s to 60 s in `checkRateLimit`, and bumping all affected `windowSeconds` from 60 → 120 so the window is always longer than the minimum TTL. A `try/catch` wrapper around KV operations is also added so any transient KV failure degrades gracefully (fail-open) instead of surfacing a 500.

- **`rate-limiter.ts`** — TTL computation changed from `Math.max(1, reset - now)` to `Math.max(60, reset - now)`; all short-window routes (`alerts`, `blog`, `card`, `og`, `feed`) moved from 60 s → 120 s windows; KV calls wrapped in `try/catch` with a permissive fallback.
- **`newsletter.ts` / `openapi-newsletter.ts`** — Newsletter subscribe/unsubscribe rate-limit window updated from 60 s → 120 s (limit stays at 5 requests per window), applied consistently across both the Hono and OpenAPI route variants.
- **Tests** — New test suite covers: TTL floor enforcement near window boundary, graceful degradation when `KV.get` throws, graceful degradation when `KV.put` throws; the `ROUTE_RATE_LIMITS` invariant assertion tightened to `windowSeconds >= 60`.
- **Side-effect worth noting** — Doubling the window from 60 s to 120 s effectively halves the sustained request rate for the affected routes (e.g., `alerts`/`blog`/`card`/`og` drop from ~60 req/min to ~30 req/min). This is an intentional tightening but worth confirming against expected traffic patterns.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — changes are well-reasoned, fully tested, and fix a real Cloudflare KV invariant without introducing logic regressions.
- The root cause (KV requires expirationTtl ≥ 60 s) is clearly documented and the fix is minimal and correct. Fixed-window slot keys ensure the raised TTL floor never bleeds counter state across windows. Graceful degradation is an explicit, acceptable trade-off for an infrastructure-adjacent helper. All new behaviours are covered by dedicated unit tests.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/worker/lib/rate-limiter.ts | Core change: TTL floor raised from 1s to 60s (Cloudflare KV requirement) + try/catch wrapper for graceful KV degradation; short-window routes bumped from 60s → 120s to keep windows ≥ TTL minimum. Logic is correct. |
| src/worker/lib/rate-limiter.test.ts | Three new test cases added: TTL floor enforcement at window boundary, KV put failure degradation, and KV get failure degradation. Existing assertion tightened to windowSeconds >= 60. Good coverage. |
| src/worker/routes/newsletter.ts | windowSeconds for subscribe and unsubscribe rate limits updated from 60 → 120 to match the new minimum window constraint. No other logic changes. |
| src/worker/routes/openapi-newsletter.ts | Same windowSeconds 60 → 120 update as newsletter.ts, applied consistently to both OpenAPI newsletter endpoints. |
| src/worker/__tests__/newsletter.test.ts | Rate-limit test fixture keys updated from rlKey(..., 60) to rlKey(..., 120) to reflect the new window size. Tests still correctly assert 429 behavior. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B[Extract IP from headers]
    B --> C[checkRateLimit\nidentifier / limit / windowSeconds]
    C --> D{KV namespace\naccessible?}
    D -- throws --> E[Fail Open\nallowed true\nremaining equals limit]
    D -- ok --> F[Compute windowSlot\nfloor of now divided by windowSeconds]
    F --> G[Compute TTL\nmax of 60 and reset minus now]
    G --> H{Key present\nin KV?}
    H -- absent --> I[KV put count=1\nwith computed TTL]
    I --> J[allowed true\nremaining = limit minus 1]
    H -- present --> K{count\n>= limit?}
    K -- yes --> L[allowed false\nremaining 0]
    K -- no --> M[KV put count+1\nwith computed TTL]
    M --> N[allowed true\nremaining = limit minus count minus 1]
    J --> O[applyRateLimitHeaders]
    L --> O
    N --> O
    E --> O
    O --> P{allowed?}
    P -- no --> Q[Return 429 plus Retry-After]
    P -- yes --> R[Continue to route handler]
```

<sub>Last reviewed commit: d0bfb06</sub>

<!-- /greptile_comment -->