### PR TITLE
fix: production health check exponential backoff

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -203,8 +203,9 @@ jobs:
           ATTEMPT=0
           MAX_ELAPSED=180
           echo "Waiting for Cloudflare edge propagation..."
-          sleep 10
-          ELAPSED=10
+          INITIAL_DELAY=10
+          sleep "$INITIAL_DELAY"
+          ELAPSED=$INITIAL_DELAY
           while [ "$ELAPSED" -lt "$MAX_ELAPSED" ]; do
             ATTEMPT=$((ATTEMPT + 1))
             STATUS=$(curl -so /dev/null --max-time 10 --connect-timeout 5 -w '%{http_code}' https://ai-grija.ro/health 2>/dev/null || echo "000")
@@ -225,7 +226,7 @@ jobs:
             sleep "$WAIT"
             ELAPSED=$((ELAPSED + WAIT))
           done
-          echo "ERROR: Production not healthy after ${MAX_ELAPSED}s"
+          echo "ERROR: Production not healthy after ${ELAPSED}s"
           exit 1
 
   post-deploy-bdd:


### PR DESCRIPTION
## Summary
- Replace fixed 5s polling with exponential backoff (attempt * 3, capped at 15s)
- Add 10s initial delay for Cloudflare edge propagation after wrangler deploy
- Two-phase check: /health (lightweight) first, then /health/deep only after basic passes
- Increase total timeout from 150s to 180s to accommodate initial delay
- Remove curl -f flag that was masking HTTP error codes

## Why
Production health check was flaky — it starts polling immediately after wrangler deploy returns, but Cloudflare edge propagation takes 5-15s. The deep health check also probes 8 endpoints including /api/alerts, which amplifies any transient issues.

## Test plan
- [ ] Merge to main and observe deploy workflow — health check should pass on first or second attempt
- [ ] Verify exponential backoff timing in workflow logs

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR overhauls the production health check step in `deploy-prod.yml`, replacing a naive fixed-interval polling loop with a two-phase progressive-backoff strategy that properly accounts for Cloudflare edge propagation time.

**Key improvements:**
- Lightweight `/health` check is gated first; `/health/deep` only runs once the basic check passes, reducing noise from the 8-endpoint deep probe during propagation windows.
- `INITIAL_DELAY=10` variable drives both the `sleep` and the initial `ELAPSED` seed, keeping them in sync.
- `--max-time` and `--connect-timeout` bounds prevent runaway curl blocking during slow Cloudflare propagation or transient service issues.
- Backoff is correctly labelled "progressive" (linear with cap: 3 → 6 → 9 → 12 → 15 → 15s…) rather than the originally mislabelled "exponential".
- Error message correctly reports actual `$ELAPSED` instead of the hardcoded `$MAX_ELAPSED`.
- All previously flagged issues have been addressed (curl timeouts, labelling, log accuracy, elapsed-time tracking, and initial-delay coupling).

<h3>Confidence Score: 4/5</h3>

- Safe to merge — changes are isolated to a CI health-check step with no impact on production code paths.
- All functional issues have been resolved: curl timeouts are bounded, elapsed-time tracking is accurate, the initial-delay coupling is fixed with a variable, and error messages report actual elapsed time. The two-phase backoff strategy with proper labeling is sound. The changes are well-isolated to the health-check job and do not affect production application code or infrastructure logic.
- No files require special attention.

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([health-check job starts]) --> B["ELAPSED=0, ATTEMPT=0, MAX_ELAPSED=180\nINITIAL_DELAY=10\nsleep 10 → ELAPSED=10"]
    B --> C{ELAPSED < 180?}
    C -- No --> Z["ERROR: Production not healthy after ELAPSED s\nexit 1 ❌"]
    C -- Yes --> D["ATTEMPT++\ncurl /health\n--max-time 10 --connect-timeout 5"]
    D --> E{HTTP 200?}
    E -- No --> F["Attempt N: HTTP X (elapsed: Ys)"]
    F --> G["WAIT = min(ATTEMPT × 3, 15)\nsleep WAIT\nELAPSED += WAIT"]
    G --> C
    E -- Yes --> H["Basic health check passed after Ys (attempt N)\ncurl /health/deep\n--max-time 30 --connect-timeout 5"]
    H --> I{HTTP 200?}
    I -- Yes --> J["Deep health check passed\nexit 0 ✅"]
    I -- No --> K["Deep health check returned HTTP X — retrying..."]
    K --> G
```

<sub>Last reviewed commit: 730df93</sub>

<!-- /greptile_comment -->