### PR TITLE
fix: aigrija — 1 stories

### DIFF
--- a/infra/index.ts
+++ b/infra/index.ts
@@ -110,7 +110,9 @@ new cloudflare.ZeroTrustAccessPolicy("admin-policy", {
   name: "Allow team",
   decision: "allow",
   precedence: 1,
-  includes: [{ emails: ["admin@zen-labs.ro"] }],
+  includes: [
+    { emailDomains: ["zp.digital", "arq.bar", "ai-grija.ro"] },
+  ],
 });
 
 // ---------------------------------------------------------------------------
@@ -201,7 +203,14 @@ new cloudflare.ZeroTrustAccessPolicy("preview-admin-policy", {
   name: "Allow team preview",
   decision: "allow",
   precedence: 1,
-  includes: [{ emails: ["admin@zen-labs.ro"] }],
+  includes: [
+    { emailDomains: ["zp.digital", "arq.bar", "ai-grija.ro"] },
+    { groups: [
+      "b9f39c45-18f7-497a-8a47-6189fa00d942",
+      "86921e1f-ac54-45b7-9104-1ec9b41eaa6b",
+      "ff8ab487-59d9-4eb8-8407-72d0d12b80c2",
+    ] },
+  ],
 });
 
 // Preview secrets — same keys, can use test values


### PR DESCRIPTION
## Summary

## Test plan
- [x] `npx vitest run` — all tests passed
- [x] `npx tsc --noEmit` — clean
- [ ] Greptile review with zero unresolved comments

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands Cloudflare Zero Trust access policies for both the production (`admin.ai-grija.ro`) and preview (`pre-admin.ai-grija.ro`) admin environments, replacing a single hard-coded email address (`admin@zen-labs.ro`) with domain-based rules covering `zp.digital`, `arq.bar`, and `ai-grija.ro`. The preview policy additionally gains three Cloudflare group includes.

**Key changes:**
- `admin-policy` (production): `emails` → `emailDomains` for three domains
- `preview-admin-policy`: same domain broadening, plus three group UUIDs added as an additional `includes` entry
- No other resources are touched

**Issues found:**
- Switching to `emailDomains` grants admin access to _every_ authenticated user from those domains — a significant policy broadening from the previous single-account allow-list. Confirm that all accounts in `zp.digital`, `arq.bar`, and `ai-grija.ro` should be able to reach the production admin panel.
- The production policy omits the `groups` block present in the preview policy; the asymmetry is intentional but undocumented.
- The three group UUIDs in the preview policy are uncommented magic strings — names or purposes should be noted inline for maintainability.

<h3>Confidence Score: 3/5</h3>

- Safe to merge if the domain-wide access grant is intentional and all accounts on the three domains are trusted team members.
- The change is small and well-scoped, but it broadens admin access from one specific email address to entire email domains without documentation of the intent. The `arq.bar` domain in particular is unexplained. The missing `groups` block on the production policy (vs. preview) is also undocumented. These are policy-level decisions that warrant explicit confirmation before merging to avoid unintended privilege escalation.
- infra/index.ts — both access policy blocks (lines 107–116 and 200–214)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| infra/index.ts | Widens Cloudflare Zero Trust access policies from a single email address to entire email domains for both production and preview admin environments; adds three hardcoded group UUIDs to the preview policy. The domain-based approach is significantly more permissive and warrants confirmation of intent. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    User([User]) --> CF[Cloudflare Zero Trust]

    CF --> ProdApp["admin.ai-grija.ro\n(ZeroTrustAccessApplication)"]
    CF --> PreviewApp["pre-admin.ai-grija.ro\n(ZeroTrustAccessApplication)"]

    ProdApp --> ProdPolicy["admin-policy\ndecision: allow"]
    PreviewApp --> PreviewPolicy["preview-admin-policy\ndecision: allow"]

    ProdPolicy --> DomainCheck1{"emailDomains\nzp.digital / arq.bar / ai-grija.ro?"}
    DomainCheck1 -->|Yes| ProdAllow(["✅ Allow — Production Admin"])
    DomainCheck1 -->|No| ProdDeny(["❌ Deny"])

    PreviewPolicy --> DomainCheck2{"emailDomains\nzp.digital / arq.bar / ai-grija.ro?"}
    PreviewPolicy --> GroupCheck{"groups\nb9f39c45 / 86921e1f / ff8ab487?"}
    DomainCheck2 -->|Yes| PreviewAllow(["✅ Allow — Preview Admin"])
    GroupCheck -->|Yes| PreviewAllow
    DomainCheck2 -->|No| GroupCheck
    GroupCheck -->|No| PreviewDeny(["❌ Deny"])
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `infra/index.ts`, line 200-214 ([link](https://github.com/zenprocess/aigrija/blob/618043bbec4c7b7c52b27147eebf4db726ad6c04/infra/index.ts#L200-L214)) 

   **Production admin policy is missing the `groups` include present in preview**

   The preview policy (`preview-admin-policy`) grants access via both `emailDomains` **and** `groups`. The production `admin-policy` (lines 107–116) only uses `emailDomains`. In Cloudflare Zero Trust, `includes` entries are evaluated as OR — so omitting the `groups` block from production is not necessarily wrong, but the asymmetry is worth a deliberate comment confirming it is intentional (e.g. "groups are for preview only — production is email-domain-gated").

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: infra/index.ts
   Line: 200-214

   Comment:
   **Production admin policy is missing the `groups` include present in preview**

   The preview policy (`preview-admin-policy`) grants access via both `emailDomains` **and** `groups`. The production `admin-policy` (lines 107–116) only uses `emailDomains`. In Cloudflare Zero Trust, `includes` entries are evaluated as OR — so omitting the `groups` block from production is not necessarily wrong, but the asymmetry is worth a deliberate comment confirming it is intentional (e.g. "groups are for preview only — production is email-domain-gated").

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20infra%2Findex.ts%0ALine%3A%20200-214%0A%0AComment%3A%0A**Production%20admin%20policy%20is%20missing%20the%20%60groups%60%20include%20present%20in%20preview**%0A%0AThe%20preview%20policy%20%28%60preview-admin-policy%60%29%20grants%20access%20via%20both%20%60emailDomains%60%20**and**%20%60groups%60.%20The%20production%20%60admin-policy%60%20%28lines%20107%E2%80%93116%29%20only%20uses%20%60emailDomains%60.%20In%20Cloudflare%20Zero%20Trust%2C%20%60includes%60%20entries%20are%20evaluated%20as%20OR%20%E2%80%94%20so%20omitting%20the%20%60groups%60%20block%20from%20production%20is%20not%20necessarily%20wrong%2C%20but%20the%20asymmetry%20is%20worth%20a%20deliberate%20comment%20confirming%20it%20is%20intentional%20%28e.g.%20%22groups%20are%20for%20preview%20only%20%E2%80%94%20production%20is%20email-domain-gated%22%29.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=zenprocess%2Faigrija"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ainfra%2Findex.ts%3A113-115%0A**%60emailDomains%60%20grants%20access%20to%20entire%20domains%2C%20not%20specific%20individuals**%0A%0ASwitching%20from%20%60emails%3A%20%5B%22admin%40zen-labs.ro%22%5D%60%20to%20%60emailDomains%3A%20%5B...%5D%60%20means%20_any_%20authenticated%20user%20whose%20email%20ends%20with%20%60zp.digital%60%2C%20%60arq.bar%60%2C%20or%20%60ai-grija.ro%60%20can%20now%20access%20the%20**production**%20admin%20panel.%20With%20the%20previous%20policy%2C%20only%20that%20one%20specific%20address%20was%20allowed.%0A%0AA%20few%20things%20worth%20confirming%3A%0A-%20Is%20%60arq.bar%60%20a%20partner%20organisation%3F%20All%20accounts%20from%20that%20domain%20will%20have%20admin%20access.%0A-%20%60ai-grija.ro%60%20is%20the%20application%20domain%20%E2%80%94%20if%20any%20non-team%20identity%20%28e.g.%20a%20service%20account%29%20authenticates%20through%20the%20configured%20IdP%20with%20an%20%60%40ai-grija.ro%60%20address%2C%20it%20would%20gain%20admin%20access%20automatically.%0A-%20The%20same%20%60emailDomains%60%20rule%20also%20applies%20to%20the%20preview%20policy%20%28line%20207%29%2C%20but%20**without**%20a%20corresponding%20%60groups%60%20block%20%E2%80%94%20see%20note%20below.%0A%0AIf%20the%20intent%20is%20to%20allow%20a%20known%2C%20bounded%20set%20of%20individuals%2C%20consider%20keeping%20%60emails%60%20%28with%20a%20list%20of%20team%20member%20addresses%29%20or%20combining%20%60emailDomains%60%20with%20a%20stricter%20%60groups%60%20block%20%E2%80%94%20as%20you%20already%20do%20for%20the%20preview%20policy.%0A%0A%23%23%23%20Issue%202%20of%203%0Ainfra%2Findex.ts%3A200-214%0A**Production%20admin%20policy%20is%20missing%20the%20%60groups%60%20include%20present%20in%20preview**%0A%0AThe%20preview%20policy%20%28%60preview-admin-policy%60%29%20grants%20access%20via%20both%20%60emailDomains%60%20**and**%20%60groups%60.%20The%20production%20%60admin-policy%60%20%28lines%20107%E2%80%93116%29%20only%20uses%20%60emailDomains%60.%20In%20Cloudflare%20Zero%20Trust%2C%20%60includes%60%20entries%20are%20evaluated%20as%20OR%20%E2%80%94%20so%20omitting%20the%20%60groups%60%20block%20from%20production%20is%20not%20necessarily%20wrong%2C%20but%20the%20asymmetry%20is%20worth%20a%20deliberate%20comment%20confirming%20it%20is%20intentional%20%28e.g.%20%22groups%20are%20for%20preview%20only%20%E2%80%94%20production%20is%20email-domain-gated%22%29.%0A%0A%23%23%23%20Issue%203%20of%203%0Ainfra%2Findex.ts%3A208-213%0A**Hardcoded%20group%20identifiers%20lack%20identifying%20comments**%0A%0AThe%20three%20Cloudflare%20group%20identifiers%20in%20the%20%60groups%60%20array%20are%20opaque%20strings%20with%20no%20indication%20of%20what%20each%20group%20represents.%20If%20a%20group%20is%20renamed%20or%20removed%20in%20the%20Cloudflare%20dashboard%2C%20there%20is%20no%20in-code%20signal%20pointing%20to%20what%20broke.%0A%0AConsider%20adding%20an%20inline%20comment%20per%20entry%20noting%20the%20group%20name%20or%20purpose%20%28e.g.%20%60%2F%2F%20QA%20team%60%2C%20%60%2F%2F%20External%20partner%60%29%20so%20future%20maintainers%20can%20audit%20access%20without%20having%20to%20cross-reference%20the%20dashboard.%0A%0A&repo=zenprocess%2Faigrija"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<sub>Last reviewed commit: 618043b</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->