### PR TITLE
fix: add nodejs_compat flag for Sentry SDK

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,7 @@
 name = "ai-grija-ro"
 main = "src/worker/index.ts"
 compatibility_date = "2026-03-01"
+compatibility_flags = ["nodejs_compat"]
 
 routes = [
   { pattern = "ai-grija.ro/*", zone_name = "ai-grija.ro" },


### PR DESCRIPTION
## Summary
- Add `nodejs_compat` compatibility flag to wrangler.toml
- Required by `@sentry/cloudflare` which imports `node:async_hooks`
- Already deployed to both production and preview

## Test plan
- [x] Production health check: ai-grija.ro/health returns 200
- [x] Preview health check: pre.ai-grija.ro/health returns 200

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single line to `wrangler.toml` — `compatibility_flags = ["nodejs_compat"]` — so the `@sentry/cloudflare` SDK (v9.47.1) can successfully import `node:async_hooks` in the Cloudflare Workers runtime. Without this flag the worker fails to initialise the Sentry wrapper (`Sentry.withSentry`) that wraps the main `ExportedHandler`.

Key observations:

- The flag is placed in the top-level config and is therefore inherited by the `[env.preview]` environment, which is consistent with the PR author's claim that both deployments were verified.
- Because `compatibility_date = "2026-03-01"` is later than `2024-09-23`, the `nodejs_compat` flag automatically activates Node.js compat v2 (the improved, expanded compatibility layer), which is the correct and expected behaviour for this version of the Sentry SDK.
- `SENTRY_DSN = ""` in `[vars]` is intentionally left empty as a placeholder; the real DSN is expected to be supplied via `wrangler secret put` so it does not appear in source control. This is a pre-existing pattern unaffected by the change.
- The `[env.preview]` `vars` table uses inline syntax, which replaces the top-level `vars` entirely, meaning `SENTRY_DSN` is not present in preview vars — it also relies on a secret or defaults to the empty-string fallback in the SDK init (`env.SENTRY_DSN || ''`). This is pre-existing and out of scope for this PR.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it is a single-line, well-understood configuration change that unblocks an already-deployed dependency.
- The change is minimal (one line in `wrangler.toml`), has a clear technical justification (`@sentry/cloudflare` requires `node:async_hooks`), is consistent with Cloudflare's documented compatibility flag behaviour, and has already been validated against both production and preview health checks.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| wrangler.toml | Adds `compatibility_flags = ["nodejs_compat"]` at the top-level so the `@sentry/cloudflare` SDK can import `node:async_hooks`; flag is inherited by the preview environment. Change is minimal, correct, and already verified against production and preview health checks. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CF as Cloudflare Runtime
    participant SW as Sentry.withSentry wrapper
    participant WH as workerHandler (fetch / scheduled)
    participant HA as Hono App (mainFetch / cdnApp / admin)
    participant SE as Sentry SDK (node:async_hooks)

    CF->>SW: incoming Request
    SW->>SE: initialise SDK with env.SENTRY_DSN
    Note over SE: requires nodejs_compat<br/>(node:async_hooks)
    SW->>WH: forward Request + Env + Ctx
    WH->>HA: route to main / cdn / admin app
    HA-->>WH: Response
    WH-->>SW: Response
    SW-->>CF: Response (errors captured in Sentry)
```

<sub>Last reviewed commit: b60195d</sub>

<!-- /greptile_comment -->