### PR TITLE
fix: harden findings — content fallback, scroll, ARIA, newsletter

### DIFF
--- a/src/ui/src/components/Checker.jsx
+++ b/src/ui/src/components/Checker.jsx
@@ -31,6 +31,17 @@ export default function Checker() {
   const isOverLimit = charCount > 5000;
 
   useEffect(() => {
+    const pendingId = sessionStorage.getItem('pendingScrollId');
+    if (pendingId) {
+      sessionStorage.removeItem('pendingScrollId');
+      requestAnimationFrame(() => {
+        const el = document.getElementById(pendingId);
+        if (el) el.scrollIntoView({ behavior: 'smooth' });
+      });
+    }
+  }, []);
+
+  useEffect(() => {
     if (rateLimitSeconds <= 0) return;
     countdownRef.current = setInterval(() => {
       setRateLimitSeconds(s => {
@@ -51,6 +62,17 @@ export default function Checker() {
       .then(data => setSocialProofCount(data.total_checks))
       .catch(() => {});
     return () => ctrl.abort();
+  }, []);
+
+  useEffect(() => {
+    const pendingId = sessionStorage.getItem('pendingScrollId');
+    if (pendingId) {
+      sessionStorage.removeItem('pendingScrollId');
+      requestAnimationFrame(() => {
+        const el = document.getElementById(pendingId);
+        if (el) el.scrollIntoView({ behavior: 'smooth' });
+      });
+    }
   }, []);
 
   const handleImageChange = (file) => {

--- a/src/ui/src/components/ContentList.jsx
+++ b/src/ui/src/components/ContentList.jsx
@@ -15,15 +15,23 @@ export default function ContentList({ category }) {
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [isFallback, setIsFallback] = useState(false);
 
   useEffect(() => {
     if (!category) return;
     setLoading(true);
     setError(null);
+    setIsFallback(false);
     fetch(`/${encodeURIComponent(category)}?limit=20&lang=${lang}`)
       .then((r) => r.json())
       .then((data) => {
-        setItems(Array.isArray(data) ? data : (Array.isArray(data.items) ? data.items : []));
+        if (data && data.fallback === true && Array.isArray(data.items)) {
+          setItems(data.items);
+          setIsFallback(true);
+        } else {
+          setItems(Array.isArray(data) ? data : (Array.isArray(data.items) ? data.items : []));
+          setIsFallback(false);
+        }
         setLoading(false);
       })
       .catch(() => {
@@ -47,6 +55,11 @@ export default function ContentList({ category }) {
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 pt-24 pb-16">
       <h1 className="text-3xl font-bold text-white mb-8 capitalize">{t(`content.${SLUG_TO_I18N_KEY[category] || category}`) || category}</h1>
+      {isFallback && (
+        <div className="mb-4 px-3 py-2 bg-yellow-900/40 border border-yellow-600/50 rounded text-sm text-yellow-300" data-testid="content-fallback-banner">
+          Conținut afișat în română — traducere în curs.
+        </div>
+      )}
       {items.length === 0 ? (
         <p className="text-center text-gray-400 py-8">{t('feed.noItems') || 'No content available'}</p>
       ) : (

--- a/src/ui/src/components/Header.jsx
+++ b/src/ui/src/components/Header.jsx
@@ -23,12 +23,9 @@ export default function Header() {
     if (element) {
       element.scrollIntoView({ behavior: 'smooth' });
     } else {
-      // Not on the home page — navigate home first, then scroll to section
+      // Not on the home page — persist scroll intent, then navigate home
+      sessionStorage.setItem('pendingScrollId', id);
       window.location.hash = '';
-      setTimeout(() => {
-        const el = document.getElementById(id);
-        if (el) el.scrollIntoView({ behavior: 'smooth' });
-      }, 100);
     }
   };
 
@@ -94,15 +91,24 @@ export default function Header() {
                 onClick={() => setIsLangOpen(!isLangOpen)}
                 className="flex items-center gap-1.5 text-gray-300 hover:text-white transition-colors text-sm font-medium px-2 py-1 rounded-lg hover:bg-white/10"
                 aria-label={t('lang_switcher.label')}
+                aria-haspopup="listbox"
+                aria-expanded={isLangOpen}
               >
                 <span className="text-base">{languageFlags?.[lang] || languages[lang]}</span>
                 <span>{languages[lang]}</span>
               </button>
               {isLangOpen && (
-                <div className="absolute right-0 top-full mt-2 w-48 glass-card border border-white/10 rounded-xl shadow-xl z-50">
+                <div
+                  role="listbox"
+                  aria-label={t('lang_switcher.label')}
+                  className="absolute right-0 top-full mt-2 w-48 glass-card border border-white/10 rounded-xl shadow-xl z-50"
+                >
                   {Object.entries(languages).map(([code]) => (
                     <button
                       key={code}
+                      role="option"
+                      aria-selected={lang === code}
+                      aria-label={languageNames[code]}
                       data-testid={`lang-option-${code}`}
                       onClick={() => { setLang(code); setIsLangOpen(false); }}
                       className={`w-full text-left px-4 py-2.5 text-sm transition-colors flex items-center gap-3 ${lang === code ? 'text-blue-400 bg-blue-500/10' : 'text-gray-300 hover:text-white hover:bg-white/10'}`}
@@ -125,15 +131,24 @@ export default function Header() {
                 onClick={() => setIsLangOpen(!isLangOpen)}
                 className="text-gray-300 hover:text-white p-3 min-h-[44px] flex items-center gap-1"
                 aria-label={t('lang_switcher.label')}
+                aria-haspopup="listbox"
+                aria-expanded={isLangOpen}
               >
                 <Globe className="w-5 h-5" />
                 <span className="text-xs font-bold">{languages[lang]}</span>
               </button>
               {isLangOpen && (
-                <div className="absolute right-0 top-full mt-2 w-48 glass-card border border-white/10 rounded-xl shadow-xl z-50">
+                <div
+                  role="listbox"
+                  aria-label={t('lang_switcher.label')}
+                  className="absolute right-0 top-full mt-2 w-48 glass-card border border-white/10 rounded-xl shadow-xl z-50"
+                >
                   {Object.entries(languages).map(([code]) => (
                     <button
                       key={code}
+                      role="option"
+                      aria-selected={lang === code}
+                      aria-label={languageNames[code]}
                       data-testid={`lang-option-mobile-${code}`}
                       onClick={() => { setLang(code); setIsLangOpen(false); }}
                       className={`w-full text-left px-4 py-2.5 text-sm transition-colors flex items-center gap-3 ${lang === code ? 'text-blue-400 bg-blue-500/10' : 'text-gray-300 hover:text-white hover:bg-white/10'}`}

--- a/src/ui/src/components/Header.test.ts
+++ b/src/ui/src/components/Header.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Regression tests for S-452: Check nav button anchor navigation broken
+ *
+ * The scrollTo function must not rely on a fixed timeout when navigating
+ * from a SPA route to home. Instead it must persist the scroll intent via
+ * sessionStorage so that the Checker component can consume it on mount.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const headerSource = readFileSync(join(process.cwd(), 'src/ui/src/components/Header.jsx'), 'utf-8');
+const checkerSource = readFileSync(join(process.cwd(), 'src/ui/src/components/Checker.jsx'), 'utf-8');
+
+describe('Header — scrollTo nav anchor fix', () => {
+  it('has header-nav-verifica button that calls scrollTo', () => {
+    expect(headerSource).toContain("data-testid=\"header-nav-verifica\"");
+    expect(headerSource).toContain("scrollTo('verifica')");
+  });
+
+  it('has mobile verifica button that calls scrollTo', () => {
+    expect(headerSource).toContain("data-testid=\"header-mobile-verifica\"");
+    expect(headerSource).toContain("scrollTo('verifica')");
+  });
+
+  it('scrollTo persists pendingScrollId to sessionStorage when element is absent', () => {
+    expect(headerSource).toContain("sessionStorage.setItem('pendingScrollId', id)");
+  });
+
+  it('scrollTo navigates home by clearing the hash', () => {
+    expect(headerSource).toContain("window.location.hash = ''");
+  });
+
+  it('does not use a fragile setTimeout for post-navigation scroll', () => {
+    // The old approach used setTimeout which races against React re-render
+    const hasTimeoutScroll = /setTimeout\s*\(\s*\(\)\s*=>[\s\S]{0,100}scrollIntoView/.test(headerSource);
+    expect(hasTimeoutScroll).toBe(false);
+  });
+});
+
+describe('Checker — pendingScrollId consumption on mount', () => {
+  it('reads pendingScrollId from sessionStorage on mount', () => {
+    expect(checkerSource).toContain("sessionStorage.getItem('pendingScrollId')");
+  });
+
+  it('removes pendingScrollId from sessionStorage after consuming it', () => {
+    expect(checkerSource).toContain("sessionStorage.removeItem('pendingScrollId')");
+  });
+
+  it('scrolls to the element after consuming the pending id', () => {
+    expect(checkerSource).toContain("el.scrollIntoView({ behavior: 'smooth' })");
+  });
+
+  it('uses requestAnimationFrame to defer the scroll until after paint', () => {
+    expect(checkerSource).toContain('requestAnimationFrame');
+  });
+
+  it('checker section has id="verifica" matching the scrollTo target', () => {
+    expect(checkerSource).toContain('id="verifica"');
+  });
+});

--- a/src/worker/routes/blog.test.ts
+++ b/src/worker/routes/blog.test.ts
@@ -171,6 +171,75 @@ describe('language filtering', () => {
   });
 });
 
+// ─── Romanian fallback behavior ───────────────────────────────────────────────
+
+describe('Romanian fallback for non-ro languages', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns Romanian content wrapped with fallback:true when lang=en returns empty', async () => {
+    const roContent = [{ title: 'Conținut Romanian', slug: { current: 'slug-ro' } }];
+    mockSanityFetch
+      .mockResolvedValueOnce([])        // lang=en returns empty
+      .mockResolvedValueOnce(roContent); // lang=ro fallback returns content
+    const env = makeEnv();
+    const res = await blog.fetch(makeRequest('/amenintari?lang=en'), env);
+    expect(res.status).toBe(200);
+    const json = await res.json() as { items: unknown[]; fallback: boolean };
+    expect(json.fallback).toBe(true);
+    expect(Array.isArray(json.items)).toBe(true);
+    expect((json.items[0] as { title: string }).title).toBe('Conținut Romanian');
+  });
+
+  it('returns empty array (no fallback wrapper) when both lang=en and lang=ro are empty', async () => {
+    mockSanityFetch.mockResolvedValue([]);
+    const env = makeEnv();
+    const res = await blog.fetch(makeRequest('/ghid?lang=en'), env);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(Array.isArray(json)).toBe(true);
+    expect((json as unknown[]).length).toBe(0);
+  });
+
+  it('does not trigger fallback when lang=ro returns empty', async () => {
+    mockSanityFetch.mockResolvedValue([]);
+    const env = makeEnv();
+    const res = await blog.fetch(makeRequest('/educatie'), env);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(Array.isArray(json)).toBe(true);
+    // Only one Sanity call — no fallback retry for ro
+    expect(mockSanityFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns plain array (no fallback wrapper) when lang=en has content', async () => {
+    const enContent = [{ title: 'English Content', slug: { current: 'en-slug' } }];
+    mockSanityFetch.mockResolvedValueOnce(enContent);
+    const env = makeEnv();
+    const res = await blog.fetch(makeRequest('/rapoarte?lang=en'), env);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(Array.isArray(json)).toBe(true);
+    expect((json as { title: string }[])[0].title).toBe('English Content');
+  });
+
+  it('fallback works for all content sections', async () => {
+    const roContent = [{ title: 'RO Content', slug: { current: 'ro-slug' } }];
+    const sections = ['ghid', 'educatie', 'rapoarte', 'povesti', 'presa'];
+    for (const section of sections) {
+      mockSanityFetch.mockClear();
+      mockSanityFetch
+        .mockResolvedValueOnce([])        // lang=en empty
+        .mockResolvedValueOnce(roContent); // lang=ro fallback
+      const env = makeEnv();
+      const res = await blog.fetch(makeRequest(`/${section}?lang=en`), env);
+      expect(res.status).toBe(200);
+      const json = await res.json() as { items: unknown[]; fallback: boolean };
+      expect(json.fallback).toBe(true);
+      expect(json.items.length).toBe(1);
+    }
+  });
+});
+
 // ─── /amenintari ──────────────────────────────────────────────────────────────
 
 describe('GET /amenintari', () => {

--- a/src/worker/routes/blog.ts
+++ b/src/worker/routes/blog.ts
@@ -118,6 +118,27 @@ function buildRss(posts: RssPost[], base: string, feedPath: string, title: strin
   ].join('\n');
 }
 
+// ─── Romanian fallback helper ────────────────────────────────────────────────
+
+type SanityListClient = <T>(query: string, params: Record<string, string | number | boolean>) => Promise<T>;
+
+async function fetchListWithFallback(
+  sanity: SanityListClient,
+  query: string,
+  lang: string,
+  from: number,
+  to: number,
+): Promise<{ posts: Record<string, unknown>[]; fallback: boolean }> {
+  const posts = (await sanity<Record<string, unknown>[]>(query, { lang, from, to })) ?? [];
+  if (posts.length === 0 && lang !== 'ro') {
+    const roPosts = (await sanity<Record<string, unknown>[]>(query, { lang: 'ro', from, to })) ?? [];
+    if (roPosts.length > 0) {
+      return { posts: roPosts, fallback: true };
+    }
+  }
+  return { posts, fallback: false };
+}
+
 // ─── /amenintari — Threat Reports ────────────────────────────────────────────
 
 blog.get('/amenintari', async (c) => {
@@ -132,14 +153,15 @@ blog.get('/amenintari', async (c) => {
   if (cached) { c.header('X-Cache', 'HIT'); c.header('Content-Type', html ? 'text/html; charset=utf-8' : 'application/json'); if (html) c.header('Cache-Control', 'public, max-age=300'); return c.body(cached); }
   try {
     const sanity = createSanityClient(c.env);
-    const posts = await sanity<Record<string, unknown>[]>(AMENINTARI_LIST_QUERY, { lang, from, to });
     if (html) {
+      const posts = await sanity<Record<string, unknown>[]>(AMENINTARI_LIST_QUERY, { lang, from, to });
       const rendered = renderBlogListPage(posts as never[], 'amenintari', lang, page, c.env.BASE_URL);
       await kvPut(c.env, cacheKey, rendered, 300);
       c.header('X-Cache', 'MISS'); c.header('Cache-Control', 'public, max-age=300');
       return c.html(rendered);
     }
-    const body = JSON.stringify(posts ?? []);
+    const { posts, fallback } = await fetchListWithFallback(sanity, AMENINTARI_LIST_QUERY, lang, from, to);
+    const body = JSON.stringify(fallback ? { items: posts, fallback: true } : posts);
     await kvPut(c.env, cacheKey, body, 300);
     c.header('X-Cache', 'MISS'); c.header('Content-Type', 'application/json');
     return c.body(body);
@@ -213,14 +235,15 @@ blog.get('/ghid', async (c) => {
   if (cached) { c.header('X-Cache', 'HIT'); c.header('Content-Type', html ? 'text/html; charset=utf-8' : 'application/json'); if (html) c.header('Cache-Control', 'public, max-age=300'); return c.body(cached); }
   try {
     const sanity = createSanityClient(c.env);
-    const posts = await sanity<Record<string, unknown>[]>(GHID_LIST_QUERY, { lang, from, to });
     if (html) {
+      const posts = await sanity<Record<string, unknown>[]>(GHID_LIST_QUERY, { lang, from, to });
       const rendered = renderBlogListPage(posts as never[], 'ghid', lang, page, c.env.BASE_URL);
       await kvPut(c.env, cacheKey, rendered, 300);
       c.header('X-Cache', 'MISS'); c.header('Cache-Control', 'public, max-age=300');
       return c.html(rendered);
     }
-    const body = JSON.stringify(posts ?? []);
+    const { posts, fallback } = await fetchListWithFallback(sanity, GHID_LIST_QUERY, lang, from, to);
+    const body = JSON.stringify(fallback ? { items: posts, fallback: true } : posts);
     await kvPut(c.env, cacheKey, body, 300);
     c.header('X-Cache', 'MISS'); c.header('Content-Type', 'application/json');
     return c.body(body);
@@ -294,14 +317,15 @@ blog.get('/educatie', async (c) => {
   if (cached) { c.header('X-Cache', 'HIT'); c.header('Content-Type', html ? 'text/html; charset=utf-8' : 'application/json'); if (html) c.header('Cache-Control', 'public, max-age=300'); return c.body(cached); }
   try {
     const sanity = createSanityClient(c.env);
-    const posts = await sanity<Record<string, unknown>[]>(EDUCATIE_LIST_QUERY, { lang, from, to });
     if (html) {
+      const posts = await sanity<Record<string, unknown>[]>(EDUCATIE_LIST_QUERY, { lang, from, to });
       const rendered = renderBlogListPage(posts as never[], 'educatie', lang, page, c.env.BASE_URL);
       await kvPut(c.env, cacheKey, rendered, 300);
       c.header('X-Cache', 'MISS'); c.header('Cache-Control', 'public, max-age=300');
       return c.html(rendered);
     }
-    const body = JSON.stringify(posts ?? []);
+    const { posts, fallback } = await fetchListWithFallback(sanity, EDUCATIE_LIST_QUERY, lang, from, to);
+    const body = JSON.stringify(fallback ? { items: posts, fallback: true } : posts);
     await kvPut(c.env, cacheKey, body, 300);
     c.header('X-Cache', 'MISS'); c.header('Content-Type', 'application/json');
     return c.body(body);
@@ -375,14 +399,15 @@ blog.get('/rapoarte', async (c) => {
   if (cached) { c.header('X-Cache', 'HIT'); c.header('Content-Type', html ? 'text/html; charset=utf-8' : 'application/json'); if (html) c.header('Cache-Control', 'public, max-age=300'); return c.body(cached); }
   try {
     const sanity = createSanityClient(c.env);
-    const posts = await sanity<Record<string, unknown>[]>(RAPOARTE_LIST_QUERY, { lang, from, to });
     if (html) {
+      const posts = await sanity<Record<string, unknown>[]>(RAPOARTE_LIST_QUERY, { lang, from, to });
       const rendered = renderBlogListPage(posts as never[], 'rapoarte', lang, page, c.env.BASE_URL);
       await kvPut(c.env, cacheKey, rendered, 300);
       c.header('X-Cache', 'MISS'); c.header('Cache-Control', 'public, max-age=300');
       return c.html(rendered);
     }
-    const body = JSON.stringify(posts ?? []);
+    const { posts, fallback } = await fetchListWithFallback(sanity, RAPOARTE_LIST_QUERY, lang, from, to);
+    const body = JSON.stringify(fallback ? { items: posts, fallback: true } : posts);
     await kvPut(c.env, cacheKey, body, 300);
     c.header('X-Cache', 'MISS'); c.header('Content-Type', 'application/json');
     return c.body(body);
@@ -435,14 +460,15 @@ blog.get('/povesti', async (c) => {
   if (cached) { c.header('X-Cache', 'HIT'); c.header('Content-Type', html ? 'text/html; charset=utf-8' : 'application/json'); if (html) c.header('Cache-Control', 'public, max-age=300'); return c.body(cached); }
   try {
     const sanity = createSanityClient(c.env);
-    const posts = await sanity<Record<string, unknown>[]>(POVESTI_LIST_QUERY, { lang, from, to });
     if (html) {
+      const posts = await sanity<Record<string, unknown>[]>(POVESTI_LIST_QUERY, { lang, from, to });
       const rendered = renderBlogListPage(posts as never[], 'povesti', lang, page, c.env.BASE_URL);
       await kvPut(c.env, cacheKey, rendered, 300);
       c.header('X-Cache', 'MISS'); c.header('Cache-Control', 'public, max-age=300');
       return c.html(rendered);
     }
-    const body = JSON.stringify(posts ?? []);
+    const { posts, fallback } = await fetchListWithFallback(sanity, POVESTI_LIST_QUERY, lang, from, to);
+    const body = JSON.stringify(fallback ? { items: posts, fallback: true } : posts);
     await kvPut(c.env, cacheKey, body, 300);
     c.header('X-Cache', 'MISS'); c.header('Content-Type', 'application/json');
     return c.body(body);
@@ -495,14 +521,15 @@ blog.get('/presa', async (c) => {
   if (cached) { c.header('X-Cache', 'HIT'); c.header('Content-Type', html ? 'text/html; charset=utf-8' : 'application/json'); if (html) c.header('Cache-Control', 'public, max-age=300'); return c.body(cached); }
   try {
     const sanity = createSanityClient(c.env);
-    const posts = await sanity<Record<string, unknown>[]>(PRESA_LIST_QUERY, { lang, from, to });
     if (html) {
+      const posts = await sanity<Record<string, unknown>[]>(PRESA_LIST_QUERY, { lang, from, to });
       const rendered = renderBlogListPage(posts as never[], 'presa', lang, page, c.env.BASE_URL);
       await kvPut(c.env, cacheKey, rendered, 300);
       c.header('X-Cache', 'MISS'); c.header('Cache-Control', 'public, max-age=300');
       return c.html(rendered);
     }
-    const body = JSON.stringify(posts ?? []);
+    const { posts, fallback } = await fetchListWithFallback(sanity, PRESA_LIST_QUERY, lang, from, to);
+    const body = JSON.stringify(fallback ? { items: posts, fallback: true } : posts);
     await kvPut(c.env, cacheKey, body, 300);
     c.header('X-Cache', 'MISS'); c.header('Content-Type', 'application/json');
     return c.body(body);

--- a/src/worker/routes/newsletter.test.ts
+++ b/src/worker/routes/newsletter.test.ts
@@ -131,6 +131,48 @@ describe('POST /api/newsletter/subscribe', () => {
     const res = await newsletter.fetch(req, makeEnv(), {} as any);
     expect(res.status).toBe(503);
   });
+
+  it('returns 503 when upstream fetch throws (network error)', async () => {
+    allowedRateLimit();
+    vi.mocked(withCircuitBreaker).mockRejectedValue(new Error('fetch failed'));
+    const req = new Request('http://localhost/api/newsletter/subscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@example.com' }),
+    });
+    const res = await newsletter.fetch(req, makeEnv(), {} as any);
+    expect(res.status).toBe(503);
+    const body = await res.json() as any;
+    expect(body.error.code).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('returns 503 when Buttondown returns 401 (invalid API key)', async () => {
+    allowedRateLimit();
+    vi.mocked(withCircuitBreaker).mockResolvedValue(new Response('Unauthorized', { status: 401 }) as any);
+    const req = new Request('http://localhost/api/newsletter/subscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@example.com' }),
+    });
+    const res = await newsletter.fetch(req, makeEnv(), {} as any);
+    expect(res.status).toBe(503);
+    const body = await res.json() as any;
+    expect(body.error.code).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('returns 503 when Buttondown returns 500', async () => {
+    allowedRateLimit();
+    vi.mocked(withCircuitBreaker).mockResolvedValue(new Response('Internal Server Error', { status: 500 }) as any);
+    const req = new Request('http://localhost/api/newsletter/subscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@example.com' }),
+    });
+    const res = await newsletter.fetch(req, makeEnv(), {} as any);
+    expect(res.status).toBe(503);
+    const body = await res.json() as any;
+    expect(body.error.code).toBe('SERVICE_UNAVAILABLE');
+  });
 });
 
 describe('POST /api/newsletter/unsubscribe', () => {
@@ -185,5 +227,19 @@ describe('POST /api/newsletter/unsubscribe', () => {
     });
     const res = await newsletter.fetch(req, makeEnv(''), {} as any);
     expect(res.status).toBe(503);
+  });
+
+  it('returns 503 when upstream fetch throws (network error)', async () => {
+    allowedRateLimit();
+    vi.mocked(withCircuitBreaker).mockRejectedValue(new Error('fetch failed'));
+    const req = new Request('http://localhost/api/newsletter/unsubscribe', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'test@example.com' }),
+    });
+    const res = await newsletter.fetch(req, makeEnv(), {} as any);
+    expect(res.status).toBe(503);
+    const body = await res.json() as any;
+    expect(body.error.code).toBe('SERVICE_UNAVAILABLE');
   });
 });

--- a/src/worker/routes/newsletter.ts
+++ b/src/worker/routes/newsletter.ts
@@ -84,23 +84,25 @@ newsletter.post('/api/newsletter/subscribe', async (c) => {
       );
     }
     return c.json(
-      { error: { code: 'UPSTREAM_ERROR', message: 'Eroare la procesarea abonarii. Incearca din nou.' } },
-      502
+      { error: { code: 'SERVICE_UNAVAILABLE', message: 'Serviciul de newsletter este temporar indisponibil. Incearca din nou mai tarziu.' } },
+      503
     );
   }
 
   if (!bdRes.ok) {
     // 400 from Buttondown usually means already subscribed or invalid email
-    const bdBody = await bdRes.json().catch((e) => { console.error("Newsletter JSON parse error:", e); return {}; }) as Record<string, unknown>;
     if (bdRes.status === 400) {
       return c.json(
         { error: { code: 'ALREADY_SUBSCRIBED', message: 'Aceasta adresa este deja abonata sau invalida.' } },
         400
       );
     }
+    if (bdRes.status === 401 || bdRes.status === 403) {
+      console.error('Newsletter: Buttondown authentication failed — check BUTTONDOWN_API_KEY binding', { status: bdRes.status });
+    }
     return c.json(
-      { error: { code: 'UPSTREAM_ERROR', message: 'Eroare la procesarea abonarii. Incearca din nou.', detail: bdBody } },
-      502
+      { error: { code: 'SERVICE_UNAVAILABLE', message: 'Serviciul de newsletter este temporar indisponibil. Incearca din nou mai tarziu.' } },
+      503
     );
   }
 
@@ -173,8 +175,8 @@ newsletter.post('/api/newsletter/unsubscribe', async (c) => {
       );
     }
     return c.json(
-      { error: { code: 'UPSTREAM_ERROR', message: 'Eroare la procesarea dezabonarii. Incearca din nou.' } },
-      502
+      { error: { code: 'SERVICE_UNAVAILABLE', message: 'Serviciul de newsletter este temporar indisponibil. Incearca din nou mai tarziu.' } },
+      503
     );
   }
 
@@ -183,7 +185,10 @@ newsletter.post('/api/newsletter/unsubscribe', async (c) => {
   }
 
   if (!bdRes.ok) {
-    return c.json({ error: { code: 'UPSTREAM_ERROR', message: 'Eroare la procesarea dezabonarii. Incearca din nou.' } }, 502);
+    if (bdRes.status === 401 || bdRes.status === 403) {
+      console.error('Newsletter: Buttondown authentication failed — check BUTTONDOWN_API_KEY binding', { status: bdRes.status });
+    }
+    return c.json({ error: { code: 'SERVICE_UNAVAILABLE', message: 'Serviciul de newsletter este temporar indisponibil. Incearca din nou mai tarziu.' } }, 503);
   }
 
   await revokeConsent(c.env, 'email', parsed.data.email).catch(() => {});


### PR DESCRIPTION
## Summary

Fixes all 4 issues from /harden pipeline (composite was 71.5, threshold 80):

- **#452** Content pages fall back to Romanian server-side when no content for selected language
- **#453** Check nav button scrolls to checker form via scrollIntoView
- **#454** Language dropdown has ARIA roles (listbox/option) + data-testid
- **#455** Newsletter returns 503 gracefully when API unavailable (was 502)

## Test results
- 1,723 tests passing (+19 new)
- 129 Playwright E2E passed against preprod
- 0 type errors

## Test plan
- [ ] Re-run /harden after deploy — target composite >= 80
- [ ] Verify content pages show Romanian content for English visitors
- [ ] Verify language dropdown accessible via screen reader

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses 4 findings from the `/harden` pipeline to bring the composite score above the 80 threshold. It adds Romanian content fallback for non-Romanian users on all 6 blog sections, replaces a fragile `setTimeout`-based scroll with a `sessionStorage` handoff between Header and Checker, adds ARIA attributes to the language dropdown, and changes newsletter error responses from 502 to 503 with `SERVICE_UNAVAILABLE` codes.

- **Content fallback** (`blog.ts`): New `fetchListWithFallback` helper retries with `lang=ro` when the requested language returns empty — clean implementation applied consistently to all 6 sections (JSON only, not SSR).
- **Scroll fix** (`Header.jsx` / `Checker.jsx`): Replaces `setTimeout` race with `sessionStorage` + `requestAnimationFrame` pattern. However, `Checker.jsx` contains an exact **duplicate `useEffect`** for the scroll logic that should be removed.
- **ARIA** (`Header.jsx`): Adds `listbox`/`option` roles and `aria-expanded`/`aria-selected` to the language switcher, but **`role="option"` is invalid on `<button>` elements** per the HTML spec — needs `<div>` elements or a `menu`/`menuitem` pattern instead.
- **Fallback banner** (`ContentList.jsx`): Shows a yellow banner when Romanian fallback is active, but the **banner text is hardcoded in Romanian** rather than using `t()`, so non-Romanian-speaking users won't understand it.
- **Newsletter** (`newsletter.ts`): 502 → 503 migration with proper `SERVICE_UNAVAILABLE` codes and auth failure logging is clean and correct.
- **Tests**: Good coverage added across all features (blog fallback, scroll regression, newsletter edge cases).

<h3>Confidence Score: 3/5</h3>

- PR is mostly safe but has three issues that should be fixed before merging: a duplicate useEffect, an invalid ARIA pattern, and a hardcoded string bypassing i18n.
- Backend changes (blog.ts, newsletter.ts) are clean and well-tested. However, the frontend has three issues: (1) a duplicate useEffect in Checker.jsx that's a clear copy-paste error, (2) role="option" on button elements which is invalid per the HTML spec — undermining the ARIA improvement this PR aims to deliver, and (3) a hardcoded Romanian string in the fallback banner that defeats the purpose of the i18n-aware fallback feature.
- `src/ui/src/components/Checker.jsx` (duplicate useEffect), `src/ui/src/components/Header.jsx` (invalid ARIA role on button), `src/ui/src/components/ContentList.jsx` (hardcoded Romanian string)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/ui/src/components/Checker.jsx | Contains a duplicate useEffect hook for pendingScrollId consumption — identical block appears at lines 33-42 and 67-76, a clear copy-paste error. |
| src/ui/src/components/ContentList.jsx | Adds Romanian fallback banner, but the banner text is hardcoded in Romanian instead of using i18n, defeating its purpose for non-Romanian users. |
| src/ui/src/components/Header.jsx | Adds ARIA roles for language dropdown and replaces setTimeout-based scroll with sessionStorage approach; however, `role="option"` is invalid on `<button>` elements per HTML spec. |
| src/worker/routes/blog.ts | Adds `fetchListWithFallback` helper for Romanian content fallback on all 6 content sections. Clean extraction, only applied to JSON responses (not SSR HTML). |
| src/worker/routes/newsletter.ts | Changes 502 responses to 503, updates error codes from UPSTREAM_ERROR to SERVICE_UNAVAILABLE, adds auth failure logging. Clean and correct changes. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ContentList as ContentList (UI)
    participant Worker as Blog Worker
    participant Sanity as Sanity CMS

    User->>ContentList: Select language (e.g., English)
    ContentList->>Worker: GET /ghid?lang=en
    Worker->>Sanity: GROQ query (lang=en)
    Sanity-->>Worker: [] (empty)
    Note over Worker: lang !== 'ro' && empty → fallback
    Worker->>Sanity: GROQ query (lang=ro)
    Sanity-->>Worker: [Romanian posts]
    Worker-->>ContentList: { items: [...], fallback: true }
    ContentList->>User: Show posts + fallback banner

    Note over User,Sanity: Newsletter error handling (502→503)

    participant Newsletter as Newsletter Worker
    participant Buttondown as Buttondown API

    User->>Newsletter: POST /api/newsletter/subscribe
    Newsletter->>Buttondown: POST /v1/subscribers
    Buttondown-->>Newsletter: 500 / network error
    Newsletter-->>User: 503 SERVICE_UNAVAILABLE
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/ui/src/components/Header.jsx`, line 107-118 ([link](https://github.com/zenprocess/aigrija/blob/ad1a757ca1dc3957a09d06d13c3d8b008c32c784/src/ui/src/components/Header.jsx#L107-L118)) 

   **Invalid ARIA: `role="option"` on `<button>`**

   Per the HTML specification's [document conformance requirements for ARIA](https://www.w3.org/TR/html-aria/#docconformance), the `<button>` element only allows roles: `checkbox`, `link`, `menuitem`, `menuitemcheckbox`, `menuitemradio`, `radio`, or `switch`. Using `role="option"` on a `<button>` is invalid and will cause HTML validation errors.

   This pattern is repeated in 4 places across the desktop and mobile language dropdowns (lines 107-118, 147-158).

   To fix this, either:
   1. Change the `<button>` elements to `<div>` elements (with `tabIndex={0}` and `onClick`/`onKeyDown` handlers), or
   2. Switch the entire pattern to use `role="menu"` / `role="menuitem"` instead of `listbox` / `option`, which is the more common pattern for dropdown menus and is valid on `<button>` elements.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/ui/src/components/Header.jsx
   Line: 107-118

   Comment:
   **Invalid ARIA: `role="option"` on `<button>`**

   Per the HTML specification's [document conformance requirements for ARIA](https://www.w3.org/TR/html-aria/#docconformance), the `<button>` element only allows roles: `checkbox`, `link`, `menuitem`, `menuitemcheckbox`, `menuitemradio`, `radio`, or `switch`. Using `role="option"` on a `<button>` is invalid and will cause HTML validation errors.

   This pattern is repeated in 4 places across the desktop and mobile language dropdowns (lines 107-118, 147-158).

   To fix this, either:
   1. Change the `<button>` elements to `<div>` elements (with `tabIndex={0}` and `onClick`/`onKeyDown` handlers), or
   2. Switch the entire pattern to use `role="menu"` / `role="menuitem"` instead of `listbox` / `option`, which is the more common pattern for dropdown menus and is valid on `<button>` elements.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fui%2Fsrc%2Fcomponents%2FHeader.jsx%0ALine%3A%20107-118%0A%0AComment%3A%0A**Invalid%20ARIA%3A%20%60role%3D%22option%22%60%20on%20%60%3Cbutton%3E%60**%0A%0APer%20the%20HTML%20specification's%20%5Bdocument%20conformance%20requirements%20for%20ARIA%5D%28https%3A%2F%2Fwww.w3.org%2FTR%2Fhtml-aria%2F%23docconformance%29%2C%20the%20%60%3Cbutton%3E%60%20element%20only%20allows%20roles%3A%20%60checkbox%60%2C%20%60link%60%2C%20%60menuitem%60%2C%20%60menuitemcheckbox%60%2C%20%60menuitemradio%60%2C%20%60radio%60%2C%20or%20%60switch%60.%20Using%20%60role%3D%22option%22%60%20on%20a%20%60%3Cbutton%3E%60%20is%20invalid%20and%20will%20cause%20HTML%20validation%20errors.%0A%0AThis%20pattern%20is%20repeated%20in%204%20places%20across%20the%20desktop%20and%20mobile%20language%20dropdowns%20%28lines%20107-118%2C%20147-158%29.%0A%0ATo%20fix%20this%2C%20either%3A%0A1.%20Change%20the%20%60%3Cbutton%3E%60%20elements%20to%20%60%3Cdiv%3E%60%20elements%20%28with%20%60tabIndex%3D%7B0%7D%60%20and%20%60onClick%60%2F%60onKeyDown%60%20handlers%29%2C%20or%0A2.%20Switch%20the%20entire%20pattern%20to%20use%20%60role%3D%22menu%22%60%20%2F%20%60role%3D%22menuitem%22%60%20instead%20of%20%60listbox%60%20%2F%20%60option%60%2C%20which%20is%20the%20more%20common%20pattern%20for%20dropdown%20menus%20and%20is%20valid%20on%20%60%3Cbutton%3E%60%20elements.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=zenprocess%2Faigrija"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fui%2Fsrc%2Fcomponents%2FChecker.jsx%3A67-76%0A**Duplicate%20%60useEffect%60%20for%20scroll%20intent**%0A%0AThis%20%60useEffect%60%20block%20%28lines%2067-76%29%20is%20an%20exact%20duplicate%20of%20the%20one%20at%20lines%2033-42.%20Both%20run%20on%20mount%20with%20%60%5B%5D%60%20dependencies%20and%20perform%20the%20same%20%60pendingScrollId%60%20sessionStorage%20read%2Fremove%2Fscroll%20logic.%20The%20second%20hook%20is%20a%20no-op%20at%20runtime%20%28the%20first%20already%20consumed%20and%20removed%20the%20key%29%2C%20but%20this%20is%20clearly%20an%20unintended%20copy-paste.%20It%20should%20be%20removed%20to%20avoid%20confusion%20and%20prevent%20future%20maintenance%20issues.%0A%0A%60%60%60suggestion%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fui%2Fsrc%2Fcomponents%2FContentList.jsx%3A59-61%0A**Hardcoded%20Romanian%20in%20fallback%20banner**%0A%0AThe%20fallback%20banner%20text%20is%20hardcoded%20in%20Romanian%20%28%60%22Con%C8%9Binut%20afi%C8%99at%20%C3%AEn%20rom%C3%A2n%C4%83%20%E2%80%94%20traducere%20%C3%AEn%20curs.%22%60%29%2C%20but%20this%20banner%20is%20specifically%20shown%20to%20users%20who%20selected%20a%20*non-Romanian*%20language%20%28e.g.%2C%20English%29.%20These%20users%20may%20not%20understand%20Romanian.%20This%20should%20use%20the%20%60t%28%29%60%20i18n%20function%20so%20the%20message%20appears%20in%20the%20user's%20selected%20language%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%3Cdiv%20className%3D%22mb-4%20px-3%20py-2%20bg-yellow-900%2F40%20border%20border-yellow-600%2F50%20rounded%20text-sm%20text-yellow-300%22%20data-testid%3D%22content-fallback-banner%22%3E%0A%20%20%20%20%20%20%20%20%20%20%7Bt%28'content.fallback_banner'%29%7D%0A%20%20%20%20%20%20%20%20%3C%2Fdiv%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fui%2Fsrc%2Fcomponents%2FHeader.jsx%3A107-118%0A**Invalid%20ARIA%3A%20%60role%3D%22option%22%60%20on%20%60%3Cbutton%3E%60**%0A%0APer%20the%20HTML%20specification's%20%5Bdocument%20conformance%20requirements%20for%20ARIA%5D%28https%3A%2F%2Fwww.w3.org%2FTR%2Fhtml-aria%2F%23docconformance%29%2C%20the%20%60%3Cbutton%3E%60%20element%20only%20allows%20roles%3A%20%60checkbox%60%2C%20%60link%60%2C%20%60menuitem%60%2C%20%60menuitemcheckbox%60%2C%20%60menuitemradio%60%2C%20%60radio%60%2C%20or%20%60switch%60.%20Using%20%60role%3D%22option%22%60%20on%20a%20%60%3Cbutton%3E%60%20is%20invalid%20and%20will%20cause%20HTML%20validation%20errors.%0A%0AThis%20pattern%20is%20repeated%20in%204%20places%20across%20the%20desktop%20and%20mobile%20language%20dropdowns%20%28lines%20107-118%2C%20147-158%29.%0A%0ATo%20fix%20this%2C%20either%3A%0A1.%20Change%20the%20%60%3Cbutton%3E%60%20elements%20to%20%60%3Cdiv%3E%60%20elements%20%28with%20%60tabIndex%3D%7B0%7D%60%20and%20%60onClick%60%2F%60onKeyDown%60%20handlers%29%2C%20or%0A2.%20Switch%20the%20entire%20pattern%20to%20use%20%60role%3D%22menu%22%60%20%2F%20%60role%3D%22menuitem%22%60%20instead%20of%20%60listbox%60%20%2F%20%60option%60%2C%20which%20is%20the%20more%20common%20pattern%20for%20dropdown%20menus%20and%20is%20valid%20on%20%60%3Cbutton%3E%60%20elements.%0A%0A&repo=zenprocess%2Faigrija"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/ui/src/components/Checker.jsx
Line: 67-76

Comment:
**Duplicate `useEffect` for scroll intent**

This `useEffect` block (lines 67-76) is an exact duplicate of the one at lines 33-42. Both run on mount with `[]` dependencies and perform the same `pendingScrollId` sessionStorage read/remove/scroll logic. The second hook is a no-op at runtime (the first already consumed and removed the key), but this is clearly an unintended copy-paste. It should be removed to avoid confusion and prevent future maintenance issues.

```suggestion
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/ui/src/components/ContentList.jsx
Line: 59-61

Comment:
**Hardcoded Romanian in fallback banner**

The fallback banner text is hardcoded in Romanian (`"Conținut afișat în română — traducere în curs."`), but this banner is specifically shown to users who selected a *non-Romanian* language (e.g., English). These users may not understand Romanian. This should use the `t()` i18n function so the message appears in the user's selected language:

```suggestion
        <div className="mb-4 px-3 py-2 bg-yellow-900/40 border border-yellow-600/50 rounded text-sm text-yellow-300" data-testid="content-fallback-banner">
          {t('content.fallback_banner')}
        </div>
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/ui/src/components/Header.jsx
Line: 107-118

Comment:
**Invalid ARIA: `role="option"` on `<button>`**

Per the HTML specification's [document conformance requirements for ARIA](https://www.w3.org/TR/html-aria/#docconformance), the `<button>` element only allows roles: `checkbox`, `link`, `menuitem`, `menuitemcheckbox`, `menuitemradio`, `radio`, or `switch`. Using `role="option"` on a `<button>` is invalid and will cause HTML validation errors.

This pattern is repeated in 4 places across the desktop and mobile language dropdowns (lines 107-118, 147-158).

To fix this, either:
1. Change the `<button>` elements to `<div>` elements (with `tabIndex={0}` and `onClick`/`onKeyDown` handlers), or
2. Switch the entire pattern to use `role="menu"` / `role="menuitem"` instead of `listbox` / `option`, which is the more common pattern for dropdown menus and is valid on `<button>` elements.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ad1a757</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->