### PR TITLE
hotfix: detail pages 404 for non-Romanian + slug object in responses

### DIFF
--- a/src/worker/routes/blog.ts
+++ b/src/worker/routes/blog.ts
@@ -54,22 +54,22 @@ async function kvDeleteByPrefix(env: Env, prefix: string): Promise<void> {
 // ─── Sanity GROQ queries ──────────────────────────────────────────────────────
 
 const GHID_LIST_QUERY = `*[(_type == "blogPost" && category == "ghid" || _type == "bankGuide") && language == $lang] | order(publishedAt desc) [$from...$to] { _type, title, "slug": slug.current, excerpt, publishedAt, mainImage, categories[]->{ title, "slug": slug.current }, author->{ name } }`;
-const GHID_POST_QUERY = `coalesce(*[_type == "blogPost" && category == "ghid" && slug.current == $slug && language == $lang][0], *[_type == "bankGuide" && slug.current == $slug && language == $lang][0]) { ..., body, author->{ name, image, bio }, categories[]->{ title, "slug": slug.current } }`;
+const GHID_POST_QUERY = `coalesce(*[_type == "blogPost" && category == "ghid" && slug.current == $slug && language == $lang][0], *[_type == "bankGuide" && slug.current == $slug && language == $lang][0]) { ..., "slug": slug.current, body, author->{ name, image, bio }, categories[]->{ title, "slug": slug.current } }`;
 
 const EDUCATIE_LIST_QUERY = `*[(_type == "blogPost" && category == "educatie" || _type == "schoolModule") && language == $lang] | order(publishedAt desc) [$from...$to] { _type, title, "slug": slug.current, excerpt, publishedAt, mainImage, categories[]->{ title, "slug": slug.current }, author->{ name } }`;
-const EDUCATIE_POST_QUERY = `coalesce(*[_type == "blogPost" && category == "educatie" && slug.current == $slug && language == $lang][0], *[_type == "schoolModule" && slug.current == $slug && language == $lang][0]) { ..., body, author->{ name, image, bio }, categories[]->{ title, "slug": slug.current } }`;
+const EDUCATIE_POST_QUERY = `coalesce(*[_type == "blogPost" && category == "educatie" && slug.current == $slug && language == $lang][0], *[_type == "schoolModule" && slug.current == $slug && language == $lang][0]) { ..., "slug": slug.current, body, author->{ name, image, bio }, categories[]->{ title, "slug": slug.current } }`;
 
 const AMENINTARI_LIST_QUERY = `*[_type == "threatReport" && language == $lang] | order(firstSeen desc) [$from...$to] { title, "slug": slug.current, excerpt, firstSeen, severity, categories[]->{ title, "slug": slug.current } }`;
-const AMENINTARI_POST_QUERY = `*[_type == "threatReport" && slug.current == $slug && language == $lang][0] { ..., body, categories[]->{ title, "slug": slug.current } }`;
+const AMENINTARI_POST_QUERY = `*[_type == "threatReport" && slug.current == $slug && language == $lang][0] { ..., "slug": slug.current, body, categories[]->{ title, "slug": slug.current } }`;
 
 const RAPOARTE_LIST_QUERY = `*[_type == "weeklyDigest" && language == $lang] | order(publishedAt desc) [$from...$to] { title, "slug": slug.current, excerpt, publishedAt, categories[]->{ title, "slug": slug.current } }`;
-const RAPOARTE_POST_QUERY = `*[_type == "weeklyDigest" && slug.current == $slug && language == $lang][0] { ..., body, categories[]->{ title, "slug": slug.current } }`;
+const RAPOARTE_POST_QUERY = `*[_type == "weeklyDigest" && slug.current == $slug && language == $lang][0] { ..., "slug": slug.current, body, categories[]->{ title, "slug": slug.current } }`;
 
 const POVESTI_LIST_QUERY = `*[_type == "communityStory" && language == $lang] | order(publishedAt desc) [$from...$to] { title, "slug": slug.current, excerpt, publishedAt, author->{ name }, categories[]->{ title, "slug": slug.current } }`;
-const POVESTI_POST_QUERY = `*[_type == "communityStory" && slug.current == $slug && language == $lang][0] { ..., body, author->{ name, image, bio }, categories[]->{ title, "slug": slug.current } }`;
+const POVESTI_POST_QUERY = `*[_type == "communityStory" && slug.current == $slug && language == $lang][0] { ..., "slug": slug.current, body, author->{ name, image, bio }, categories[]->{ title, "slug": slug.current } }`;
 
 const PRESA_LIST_QUERY = `*[_type == "pressRelease" && language == $lang] | order(publishedAt desc) [$from...$to] { title, "slug": slug.current, excerpt, publishedAt, categories[]->{ title, "slug": slug.current } }`;
-const PRESA_POST_QUERY = `*[_type == "pressRelease" && slug.current == $slug && language == $lang][0] { ..., body, categories[]->{ title, "slug": slug.current } }`;
+const PRESA_POST_QUERY = `*[_type == "pressRelease" && slug.current == $slug && language == $lang][0] { ..., "slug": slug.current, body, categories[]->{ title, "slug": slug.current } }`;
 
 const SITEMAP_QUERY = `{
   "ghid": *[(_type == "blogPost" && category == "ghid") || _type == "bankGuide"] { "slug": slug.current, "language": language, "_updatedAt": _updatedAt },
@@ -139,6 +139,22 @@ async function fetchListWithFallback(
   return { posts, fallback: false };
 }
 
+async function fetchPostWithFallback(
+  sanity: SanityListClient,
+  query: string,
+  slug: string,
+  lang: string,
+): Promise<{ post: Record<string, unknown> | null; fallback: boolean }> {
+  const post = await sanity<Record<string, unknown>>(query, { slug, lang });
+  if (!post && lang !== 'ro') {
+    const roPost = await sanity<Record<string, unknown>>(query, { slug, lang: 'ro' });
+    if (roPost) {
+      return { post: roPost, fallback: true };
+    }
+  }
+  return { post, fallback: false };
+}
+
 // ─── /amenintari — Threat Reports ────────────────────────────────────────────
 
 blog.get('/amenintari', async (c) => {
@@ -203,8 +219,9 @@ blog.get('/amenintari/:slug', async (c) => {
   if (cached) { c.header('X-Cache', 'HIT'); c.header('Content-Type', html ? 'text/html; charset=utf-8' : 'application/json'); if (html) c.header('Cache-Control', 'public, max-age=300'); return c.body(cached); }
   try {
     const sanity = createSanityClient(c.env);
-    const post = await sanity<Record<string, unknown>>(AMENINTARI_POST_QUERY, { slug, lang });
+    const { post, fallback } = await fetchPostWithFallback(sanity, AMENINTARI_POST_QUERY, slug, lang);
     if (!post) return c.json({ error: { code: 'NOT_FOUND', message: 'Raportul nu a fost gasit.' }, request_id: 'unknown' }, 404);
+    if (fallback) c.header('X-Content-Language', 'ro');
     if (html) {
       const rendered = renderBlogPostPage(post as never, 'amenintari', lang, c.env.BASE_URL);
       await kvPut(c.env, cacheKey, rendered, 600);
@@ -285,8 +302,9 @@ blog.get('/ghid/:slug', async (c) => {
   if (cached) { c.header('X-Cache', 'HIT'); c.header('Content-Type', html ? 'text/html; charset=utf-8' : 'application/json'); if (html) c.header('Cache-Control', 'public, max-age=300'); return c.body(cached); }
   try {
     const sanity = createSanityClient(c.env);
-    const post = await sanity<Record<string, unknown>>(GHID_POST_QUERY, { slug, lang });
+    const { post, fallback } = await fetchPostWithFallback(sanity, GHID_POST_QUERY, slug, lang);
     if (!post) return c.json({ error: { code: 'NOT_FOUND', message: 'Ghidul nu a fost gasit.' }, request_id: 'unknown' }, 404);
+    if (fallback) c.header('X-Content-Language', 'ro');
     if (html) {
       const rendered = renderBlogPostPage(post as never, 'ghid', lang, c.env.BASE_URL);
       await kvPut(c.env, cacheKey, rendered, 600);
@@ -367,8 +385,9 @@ blog.get('/educatie/:slug', async (c) => {
   if (cached) { c.header('X-Cache', 'HIT'); c.header('Content-Type', html ? 'text/html; charset=utf-8' : 'application/json'); if (html) c.header('Cache-Control', 'public, max-age=300'); return c.body(cached); }
   try {
     const sanity = createSanityClient(c.env);
-    const post = await sanity<Record<string, unknown>>(EDUCATIE_POST_QUERY, { slug, lang });
+    const { post, fallback } = await fetchPostWithFallback(sanity, EDUCATIE_POST_QUERY, slug, lang);
     if (!post) return c.json({ error: { code: 'NOT_FOUND', message: 'Articolul de educatie nu a fost gasit.' }, request_id: 'unknown' }, 404);
+    if (fallback) c.header('X-Content-Language', 'ro');
     if (html) {
       const rendered = renderBlogPostPage(post as never, 'educatie', lang, c.env.BASE_URL);
       await kvPut(c.env, cacheKey, rendered, 600);
@@ -428,8 +447,9 @@ blog.get('/rapoarte/:slug', async (c) => {
   if (cached) { c.header('X-Cache', 'HIT'); c.header('Content-Type', html ? 'text/html; charset=utf-8' : 'application/json'); if (html) c.header('Cache-Control', 'public, max-age=300'); return c.body(cached); }
   try {
     const sanity = createSanityClient(c.env);
-    const post = await sanity<Record<string, unknown>>(RAPOARTE_POST_QUERY, { slug, lang });
+    const { post, fallback } = await fetchPostWithFallback(sanity, RAPOARTE_POST_QUERY, slug, lang);
     if (!post) return c.json({ error: { code: 'NOT_FOUND', message: 'Raportul saptamanal nu a fost gasit.' }, request_id: 'unknown' }, 404);
+    if (fallback) c.header('X-Content-Language', 'ro');
     if (html) {
       const rendered = renderBlogPostPage(post as never, 'rapoarte', lang, c.env.BASE_URL);
       await kvPut(c.env, cacheKey, rendered, 600);
@@ -489,8 +509,9 @@ blog.get('/povesti/:slug', async (c) => {
   if (cached) { c.header('X-Cache', 'HIT'); c.header('Content-Type', html ? 'text/html; charset=utf-8' : 'application/json'); if (html) c.header('Cache-Control', 'public, max-age=300'); return c.body(cached); }
   try {
     const sanity = createSanityClient(c.env);
-    const post = await sanity<Record<string, unknown>>(POVESTI_POST_QUERY, { slug, lang });
+    const { post, fallback } = await fetchPostWithFallback(sanity, POVESTI_POST_QUERY, slug, lang);
     if (!post) return c.json({ error: { code: 'NOT_FOUND', message: 'Povestea nu a fost gasita.' }, request_id: 'unknown' }, 404);
+    if (fallback) c.header('X-Content-Language', 'ro');
     if (html) {
       const rendered = renderBlogPostPage(post as never, 'povesti', lang, c.env.BASE_URL);
       await kvPut(c.env, cacheKey, rendered, 600);
@@ -550,8 +571,9 @@ blog.get('/presa/:slug', async (c) => {
   if (cached) { c.header('X-Cache', 'HIT'); c.header('Content-Type', html ? 'text/html; charset=utf-8' : 'application/json'); if (html) c.header('Cache-Control', 'public, max-age=300'); return c.body(cached); }
   try {
     const sanity = createSanityClient(c.env);
-    const post = await sanity<Record<string, unknown>>(PRESA_POST_QUERY, { slug, lang });
+    const { post, fallback } = await fetchPostWithFallback(sanity, PRESA_POST_QUERY, slug, lang);
     if (!post) return c.json({ error: { code: 'NOT_FOUND', message: 'Comunicatul de presa nu a fost gasit.' }, request_id: 'unknown' }, 404);
+    if (fallback) c.header('X-Content-Language', 'ro');
     if (html) {
       const rendered = renderBlogPostPage(post as never, 'presa', lang, c.env.BASE_URL);
       await kvPut(c.env, cacheKey, rendered, 600);


### PR DESCRIPTION
Detail GROQ queries used ... spread returning raw slug objects. Also no language fallback on detail endpoints. Fixed both across all 6 categories.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hotfix addresses two pre-existing bugs in `src/worker/routes/blog.ts`: GROQ detail queries that spread raw Sanity slug objects (now resolved with an explicit `"slug": slug.current` projection) and missing Romanian-language fallback on the six `/:slug` detail endpoints (now handled via a new `fetchPostWithFallback` helper mirroring the existing `fetchListWithFallback`). The changes are correctly structured and solve the reported 404s for non-Romanian requests.

However, two new issues are introduced by the fallback handling:

- **Fallback not persisted in cache (all 6 JSON detail handlers):** When a Romanian fallback post is served, the JSON body is a bare post object with no `fallback: true` field. The response is cached under the non-Romanian language key (e.g. `amenintari:post:en:slug`). All subsequent cache hits skip the `X-Content-Language: ro` header, so API consumers can only detect the fallback on the very first (MISS) response — inconsistent with the list endpoints which do embed `{ items, fallback: true }` in the body.
- **HTML rendered with wrong language on fallback (all 6 HTML detail handlers):** `renderBlogPostPage` is called with the *requested* lang (e.g. `'en'`) even when the content is a Romanian fallback. This causes `<html lang="en">` on a Romanian-content page and — more visibly — the `lang-disclaimer` renders as *"This article was automatically translated. The Romanian version is the official version."*, which is factually incorrect: the content was **not** translated, it is the original Romanian text. This misleading HTML is then cached and served to all future visitors at that URL+lang combination.

<h3>Confidence Score: 3/5</h3>

- Safe to merge as a partial fix, but two regressions in the fallback caching/HTML rendering should be addressed before or immediately after.
- The slug fix and the fallback 404 fix are correct and solve the reported issues. However, the fallback path introduces a cache-consistency bug (fallback indicator lost after first request) and an HTML correctness bug (wrong lang attribute + incorrect "translated" disclaimer) that affect all 6 detail routes in both JSON and HTML modes.
- src/worker/routes/blog.ts — specifically the JSON and HTML response paths inside every `/:slug` handler when `fallback === true`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/worker/routes/blog.ts | Fixes slug object leak in GROQ projections and adds `fetchPostWithFallback` for all 6 detail routes, but caches fallback responses without a fallback indicator (unlike list endpoints) and renders HTML with the wrong `lang` when a fallback is used, producing an incorrect `<html lang>` attribute and a misleading "automatically translated" disclaimer. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client (lang=en)
    participant W as Worker /:slug handler
    participant KV as KV Cache
    participant S as Sanity

    C->>W: GET /amenintari/my-post?lang=en
    W->>KV: GET amenintari:post:en:my-post
    KV-->>W: null (MISS)
    W->>S: query(AMENINTARI_POST_QUERY, {slug, lang:"en"})
    S-->>W: null (no English version)
    note over W: lang !== "ro", so try fallback
    W->>S: query(AMENINTARI_POST_QUERY, {slug, lang:"ro"})
    S-->>W: Romanian post
    W->>W: fallback=true → set X-Content-Language:ro header
    note over W,KV: ⚠ Bug A: body=JSON.stringify(post) — no fallback:true field<br/>⚠ Bug B (HTML): renderBlogPostPage(post, cat, "en", base) — wrong lang
    W->>KV: PUT amenintari:post:en:my-post = Romanian content (TTL 600s)
    W-->>C: Romanian post + X-Content-Language:ro ✓ (first request OK)

    C->>W: GET /amenintari/my-post?lang=en (second request)
    W->>KV: GET amenintari:post:en:my-post
    KV-->>W: Romanian content (HIT)
    note over W: ⚠ X-Content-Language:ro NOT set — fallback invisible to client
    W-->>C: Romanian post — NO fallback indicator ✗
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/worker/routes/blog.ts`, line 231-234 ([link](https://github.com/zenprocess/aigrija/blob/92424d76742fb885f45af70049b7674bc849c3f2/src/worker/routes/blog.ts#L231-L234)) 

   **Fallback response cached without fallback indicator**

   When `fallback === true`, the JSON body is `JSON.stringify(post)` — a bare post object with no `fallback: true` field — and it gets stored under the requested-language cache key (e.g. `amenintari:post:en:some-slug`). On every subsequent cache HIT the early-return path runs:

   ```ts
   if (cached) {
     c.header('X-Cache', 'HIT');
     // ...
     return c.body(cached);
   }
   ```

   `X-Content-Language: ro` is **never** set on cache hits, so any API consumer that relies on that header to detect language fallback will only see it on the very first (MISS) response and never again.

   This is inconsistent with how list endpoints handle the same situation: they wrap the response in `{ items: posts, fallback: true }` so the indicator is baked into the body and survives caching. Consider doing the same for post responses:

   ```ts
   const body = JSON.stringify(fallback ? { post, fallback: true } : post);
   ```

   This same issue exists in all six `/:slug` handlers: `/ghid/:slug` (line 314), `/educatie/:slug` (line 397), `/rapoarte/:slug` (line 459), `/povesti/:slug` (line 521), `/presa/:slug` (line 583).


2. `src/worker/routes/blog.ts`, line 225-229 ([link](https://github.com/zenprocess/aigrija/blob/92424d76742fb885f45af70049b7674bc849c3f2/src/worker/routes/blog.ts#L225-L229)) 

   **Incorrect HTML `lang` attribute and misleading disclaimer on fallback**

   When `fallback === true`, `renderBlogPostPage` is called with the *requested* `lang` (e.g. `'en'`) even though the post content is actually Romanian. The template then:

   1. Emits `<html lang="en">` — incorrect for content that is actually in Romanian; hurts accessibility (screen readers, browser translation) and SEO.
   2. Renders the `lang-disclaimer` — `'This article was automatically translated. The Romanian version is the official version.'` — which is factually wrong here: the content has **not** been translated; it is the original Romanian text served verbatim because no English version exists.

   Both the wrong `lang` attribute and the false "automatically translated" notice get stored in KV and served to all future visitors who request that URL with `?lang=en`.

   The fix is to pass `'ro'` as the language argument to `renderBlogPostPage` (and `kvPut`) when serving a fallback:

   ```ts
   const effectiveLang = fallback ? 'ro' : lang;
   const rendered = renderBlogPostPage(post as never, 'amenintari', effectiveLang, c.env.BASE_URL);
   await kvPut(c.env, cacheKey, rendered, 600);
   ```

   The same issue exists in all six `/:slug` HTML paths: `/ghid/:slug` (line 309), `/educatie/:slug` (line 392), `/rapoarte/:slug` (line 454), `/povesti/:slug` (line 516), `/presa/:slug` (line 578).

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fworker%2Froutes%2Fblog.ts%3A231-234%0A**Fallback%20response%20cached%20without%20fallback%20indicator**%0A%0AWhen%20%60fallback%20%3D%3D%3D%20true%60%2C%20the%20JSON%20body%20is%20%60JSON.stringify%28post%29%60%20%E2%80%94%20a%20bare%20post%20object%20with%20no%20%60fallback%3A%20true%60%20field%20%E2%80%94%20and%20it%20gets%20stored%20under%20the%20requested-language%20cache%20key%20%28e.g.%20%60amenintari%3Apost%3Aen%3Asome-slug%60%29.%20On%20every%20subsequent%20cache%20HIT%20the%20early-return%20path%20runs%3A%0A%0A%60%60%60ts%0Aif%20%28cached%29%20%7B%0A%20%20c.header%28'X-Cache'%2C%20'HIT'%29%3B%0A%20%20%2F%2F%20...%0A%20%20return%20c.body%28cached%29%3B%0A%7D%0A%60%60%60%0A%0A%60X-Content-Language%3A%20ro%60%20is%20**never**%20set%20on%20cache%20hits%2C%20so%20any%20API%20consumer%20that%20relies%20on%20that%20header%20to%20detect%20language%20fallback%20will%20only%20see%20it%20on%20the%20very%20first%20%28MISS%29%20response%20and%20never%20again.%0A%0AThis%20is%20inconsistent%20with%20how%20list%20endpoints%20handle%20the%20same%20situation%3A%20they%20wrap%20the%20response%20in%20%60%7B%20items%3A%20posts%2C%20fallback%3A%20true%20%7D%60%20so%20the%20indicator%20is%20baked%20into%20the%20body%20and%20survives%20caching.%20Consider%20doing%20the%20same%20for%20post%20responses%3A%0A%0A%60%60%60ts%0Aconst%20body%20%3D%20JSON.stringify%28fallback%20%3F%20%7B%20post%2C%20fallback%3A%20true%20%7D%20%3A%20post%29%3B%0A%60%60%60%0A%0AThis%20same%20issue%20exists%20in%20all%20six%20%60%2F%3Aslug%60%20handlers%3A%20%60%2Fghid%2F%3Aslug%60%20%28line%20314%29%2C%20%60%2Feducatie%2F%3Aslug%60%20%28line%20397%29%2C%20%60%2Frapoarte%2F%3Aslug%60%20%28line%20459%29%2C%20%60%2Fpovesti%2F%3Aslug%60%20%28line%20521%29%2C%20%60%2Fpresa%2F%3Aslug%60%20%28line%20583%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fworker%2Froutes%2Fblog.ts%3A225-229%0A**Incorrect%20HTML%20%60lang%60%20attribute%20and%20misleading%20disclaimer%20on%20fallback**%0A%0AWhen%20%60fallback%20%3D%3D%3D%20true%60%2C%20%60renderBlogPostPage%60%20is%20called%20with%20the%20*requested*%20%60lang%60%20%28e.g.%20%60'en'%60%29%20even%20though%20the%20post%20content%20is%20actually%20Romanian.%20The%20template%20then%3A%0A%0A1.%20Emits%20%60%3Chtml%20lang%3D%22en%22%3E%60%20%E2%80%94%20incorrect%20for%20content%20that%20is%20actually%20in%20Romanian%3B%20hurts%20accessibility%20%28screen%20readers%2C%20browser%20translation%29%20and%20SEO.%0A2.%20Renders%20the%20%60lang-disclaimer%60%20%E2%80%94%20%60'This%20article%20was%20automatically%20translated.%20The%20Romanian%20version%20is%20the%20official%20version.'%60%20%E2%80%94%20which%20is%20factually%20wrong%20here%3A%20the%20content%20has%20**not**%20been%20translated%3B%20it%20is%20the%20original%20Romanian%20text%20served%20verbatim%20because%20no%20English%20version%20exists.%0A%0ABoth%20the%20wrong%20%60lang%60%20attribute%20and%20the%20false%20%22automatically%20translated%22%20notice%20get%20stored%20in%20KV%20and%20served%20to%20all%20future%20visitors%20who%20request%20that%20URL%20with%20%60%3Flang%3Den%60.%0A%0AThe%20fix%20is%20to%20pass%20%60'ro'%60%20as%20the%20language%20argument%20to%20%60renderBlogPostPage%60%20%28and%20%60kvPut%60%29%20when%20serving%20a%20fallback%3A%0A%0A%60%60%60ts%0Aconst%20effectiveLang%20%3D%20fallback%20%3F%20'ro'%20%3A%20lang%3B%0Aconst%20rendered%20%3D%20renderBlogPostPage%28post%20as%20never%2C%20'amenintari'%2C%20effectiveLang%2C%20c.env.BASE_URL%29%3B%0Aawait%20kvPut%28c.env%2C%20cacheKey%2C%20rendered%2C%20600%29%3B%0A%60%60%60%0A%0AThe%20same%20issue%20exists%20in%20all%20six%20%60%2F%3Aslug%60%20HTML%20paths%3A%20%60%2Fghid%2F%3Aslug%60%20%28line%20309%29%2C%20%60%2Feducatie%2F%3Aslug%60%20%28line%20392%29%2C%20%60%2Frapoarte%2F%3Aslug%60%20%28line%20454%29%2C%20%60%2Fpovesti%2F%3Aslug%60%20%28line%20516%29%2C%20%60%2Fpresa%2F%3Aslug%60%20%28line%20578%29.%0A%0A&repo=zenprocess%2Faigrija"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/worker/routes/blog.ts
Line: 231-234

Comment:
**Fallback response cached without fallback indicator**

When `fallback === true`, the JSON body is `JSON.stringify(post)` — a bare post object with no `fallback: true` field — and it gets stored under the requested-language cache key (e.g. `amenintari:post:en:some-slug`). On every subsequent cache HIT the early-return path runs:

```ts
if (cached) {
  c.header('X-Cache', 'HIT');
  // ...
  return c.body(cached);
}
```

`X-Content-Language: ro` is **never** set on cache hits, so any API consumer that relies on that header to detect language fallback will only see it on the very first (MISS) response and never again.

This is inconsistent with how list endpoints handle the same situation: they wrap the response in `{ items: posts, fallback: true }` so the indicator is baked into the body and survives caching. Consider doing the same for post responses:

```ts
const body = JSON.stringify(fallback ? { post, fallback: true } : post);
```

This same issue exists in all six `/:slug` handlers: `/ghid/:slug` (line 314), `/educatie/:slug` (line 397), `/rapoarte/:slug` (line 459), `/povesti/:slug` (line 521), `/presa/:slug` (line 583).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/worker/routes/blog.ts
Line: 225-229

Comment:
**Incorrect HTML `lang` attribute and misleading disclaimer on fallback**

When `fallback === true`, `renderBlogPostPage` is called with the *requested* `lang` (e.g. `'en'`) even though the post content is actually Romanian. The template then:

1. Emits `<html lang="en">` — incorrect for content that is actually in Romanian; hurts accessibility (screen readers, browser translation) and SEO.
2. Renders the `lang-disclaimer` — `'This article was automatically translated. The Romanian version is the official version.'` — which is factually wrong here: the content has **not** been translated; it is the original Romanian text served verbatim because no English version exists.

Both the wrong `lang` attribute and the false "automatically translated" notice get stored in KV and served to all future visitors who request that URL with `?lang=en`.

The fix is to pass `'ro'` as the language argument to `renderBlogPostPage` (and `kvPut`) when serving a fallback:

```ts
const effectiveLang = fallback ? 'ro' : lang;
const rendered = renderBlogPostPage(post as never, 'amenintari', effectiveLang, c.env.BASE_URL);
await kvPut(c.env, cacheKey, rendered, 600);
```

The same issue exists in all six `/:slug` HTML paths: `/ghid/:slug` (line 309), `/educatie/:slug` (line 392), `/rapoarte/:slug` (line 454), `/povesti/:slug` (line 516), `/presa/:slug` (line 578).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 92424d7</sub>

<!-- /greptile_comment -->