### PR TITLE
fix: deploy-prod Pulumi login + secret conditionals

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -99,6 +99,8 @@ jobs:
     name: Infrastructure validation
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && !inputs.skip_tests
+    env:
+      HAS_PULUMI: ${{ secrets.PULUMI_CONFIG_PASSPHRASE != '' && 'true' || '' }}
     steps:
       - uses: actions/checkout@v4
       - name: Validate infra config
@@ -114,19 +116,19 @@ jobs:
       - name: Install policy pack
         run: cd infra/policy && npm install
       - name: Pulumi login (R2 backend)
-        if: env.PULUMI_CONFIG_PASSPHRASE != ''
-        run: pulumi login s3://ai-grija-pulumi-state --secrets-provider passphrase
+        if: env.HAS_PULUMI
+        run: pulumi login "s3://ai-grija-pulumi-state?region=auto&endpoint=https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
         env:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL_S3: ${{ secrets.AWS_ENDPOINT_URL_S3 }}
       - name: Pulumi preview with CrossGuard
-        if: env.PULUMI_CONFIG_PASSPHRASE != ''
+        if: env.HAS_PULUMI
         uses: pulumi/actions@v6
         with:
           command: preview
-          stack-name: production
+          stack-name: dev
           work-dir: infra
           policyPacks: infra/policy
         env:
@@ -136,10 +138,8 @@ jobs:
           AWS_ENDPOINT_URL_S3: ${{ secrets.AWS_ENDPOINT_URL_S3 }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       - name: Warn if Pulumi passphrase missing
-        if: env.PULUMI_CONFIG_PASSPHRASE == ''
+        if: ${{ !env.HAS_PULUMI }}
         run: echo "::warning::PULUMI_CONFIG_PASSPHRASE not set — infrastructure validation skipped. Add it to GitHub secrets."
-        env:
-          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
 
   deploy:
     name: Deploy to Cloudflare Workers
@@ -161,7 +161,7 @@ jobs:
       - name: Install policy pack
         run: cd infra/policy && npm install
       - name: Pulumi login (R2 backend)
-        run: pulumi login s3://ai-grija-pulumi-state --secrets-provider passphrase
+        run: pulumi login "s3://ai-grija-pulumi-state?region=auto&endpoint=https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
         env:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}


### PR DESCRIPTION
## Summary

- Fix `--secrets-provider passphrase` (invalid pulumi login flag)
- Use R2-compatible S3 URL with account ID
- Fix secret conditionals (job-level HAS_PULUMI env var)
- Stack name: dev (matches Pulumi.dev.yaml)

Same fixes already applied to pr-checks.yml in PR #473.

## Test plan

- [x] Identical pattern to pr-checks.yml which passes CI

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports three fixes from `pr-checks.yml` (landed in PR #473) into `deploy-prod.yml`: replaces the invalid `--secrets-provider passphrase` flag on `pulumi login` with a proper R2-compatible S3 URL containing the Cloudflare account ID, moves the Pulumi secret availability check to a job-level `HAS_PULUMI` env var so step `if:` conditionals evaluate correctly, and aligns `stack-name` from the non-existent `production` value to `dev` (matching `Pulumi.dev.yaml`).

**Key changes:**
- `pulumi login` now uses `s3://...?region=auto&endpoint=https://<account>.r2.cloudflarestorage.com` — correct R2-compatible syntax
- `HAS_PULUMI` computed at job-level via `secrets.PULUMI_CONFIG_PASSPHRASE != '' && 'true' || ''` fixes step-level secret comparison which GitHub Actions does not support
- `stack-name: dev` is now consistent between `infra-validate` (preview) and `deploy` (up)
- Unnecessary `env: PULUMI_CONFIG_PASSPHRASE` removed from the "warn" step (improvement over `pr-checks.yml`)
- The `infra-validate` job's Pulumi login still uses `secrets.AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_ENDPOINT_URL_S3` while the `deploy` job uses `secrets.R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY / R2_ENDPOINT_URL` — both target the same bucket, so this is benign if the secrets are aliases, but worth verifying

<h3>Confidence Score: 4/5</h3>

- Safe to merge — the fixes are correct and directly mirror the already-passing pattern from `pr-checks.yml`
- All three fixes (R2 URL format, job-level env var for conditional, stack name alignment) are well-understood and verified against the reference implementation in `pr-checks.yml`. The only open question is whether `secrets.AWS_ACCESS_KEY_ID` and `secrets.R2_ACCESS_KEY_ID` resolve to the same R2 credentials — if they do, the workflow is fully correct. Score is 4 rather than 5 solely because of this unverified credential asymmetry between the two jobs.
- No files require special attention beyond confirming that `secrets.AWS_ACCESS_KEY_ID` and `secrets.R2_ACCESS_KEY_ID` point to equivalent R2 credentials

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-prod.yml | Fixes invalid `--secrets-provider passphrase` Pulumi login flag, adds R2-compatible endpoint URL, moves secret detection to job-level `HAS_PULUMI` env var for reliable step conditionals, and aligns `stack-name` with `Pulumi.dev.yaml`. Credentials in `infra-validate` still use generic `AWS_*` secret names while `deploy` uses `R2_*` names — functionally fine if the secrets resolve to the same values, but worth confirming. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant ENV as Job Env (HAS_PULUMI)
    participant R2 as Cloudflare R2
    participant Pulumi as Pulumi Engine
    participant CF as Cloudflare Workers

    GH->>ENV: Evaluate PULUMI_CONFIG_PASSPHRASE != '' → HAS_PULUMI

    alt HAS_PULUMI == 'true'
        GH->>R2: pulumi login s3://...?endpoint=<account>.r2.cloudflarestorage.com
        R2-->>GH: Authenticated
        GH->>Pulumi: pulumi preview --stack dev (CrossGuard)
        Pulumi-->>GH: Preview result
    else HAS_PULUMI == ''
        GH->>GH: ::warning:: passphrase not set — skipping
    end

    GH->>R2: pulumi login (deploy job, unconditional)
    R2-->>GH: Authenticated
    GH->>Pulumi: pulumi up --stack dev
    Pulumi-->>GH: Infrastructure applied
    GH->>CF: wrangler deploy
    CF-->>GH: Deployed
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fdeploy-prod.yml%3A122-125%0A**AWS%20credential%20names%20differ%20from%20%60deploy%60%20job**%0A%0AThe%20%60infra-validate%60%20job%20uses%20generic%20secret%20names%20%28%60AWS_ACCESS_KEY_ID%60%2C%20%60AWS_SECRET_ACCESS_KEY%60%2C%20%60AWS_ENDPOINT_URL_S3%60%29%20while%20the%20%60deploy%60%20job%20uses%20R2-specific%20names%20%28%60R2_ACCESS_KEY_ID%60%2C%20%60R2_SECRET_ACCESS_KEY%60%2C%20%60R2_ENDPOINT_URL%60%29%20%E2%80%94%20both%20pointing%20at%20the%20same%20%60ai-grija-pulumi-state%60%20bucket.%20This%20asymmetry%20was%20pre-existing%20and%20mirrors%20the%20same%20pattern%20already%20established%20in%20%60pr-checks.yml%60%20%28lines%20102-104%29%2C%20so%20it's%20a%20known%20configuration%20choice%3B%20however%2C%20if%20these%20are%20distinct%20secret%20values%20rather%20than%20aliases%2C%20validation%20could%20be%20targeting%20a%20different%20backend%20than%20production%20deployment.%20Worth%20confirming%20both%20secret%20sets%20resolve%20to%20the%20same%20R2%20credentials.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20PULUMI_CONFIG_PASSPHRASE%3A%20%24%7B%7B%20secrets.PULUMI_CONFIG_PASSPHRASE%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20AWS_ACCESS_KEY_ID%3A%20%24%7B%7B%20secrets.R2_ACCESS_KEY_ID%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20AWS_SECRET_ACCESS_KEY%3A%20%24%7B%7B%20secrets.R2_SECRET_ACCESS_KEY%20%7D%7D%0A%20%20%20%20%20%20%20%20%20%20AWS_ENDPOINT_URL_S3%3A%20%24%7B%7B%20secrets.R2_ENDPOINT_URL%20%7D%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fdeploy-prod.yml%3A131%0A**%60dev%60%20stack%20in%20production%20validation**%0A%0AThe%20%60stack-name%60%20is%20now%20%60dev%60%20%28matching%20%60Pulumi.dev.yaml%60%29%2C%20which%20aligns%20with%20the%20%60deploy%60%20job%20at%20line%20174.%20However%2C%20the%20workflow%20is%20named%20%22Deploy%20Production%22%20and%20previously%20used%20%60stack-name%3A%20production%60.%20If%20there%20is%20no%20%60Pulumi.production.yaml%60%20and%20%60dev%60%20is%20the%20only%20stack%2C%20this%20is%20correct.%20Just%20confirming%20this%20is%20intentional%20and%20not%20accidentally%20pointing%20production%20validation%20at%20a%20non-production%20stack%20%E2%80%94%20the%20PR%20description%20confirms%20it%20is%2C%20so%20this%20is%20just%20a%20heads-up%20for%20any%20future%20reader.%0A%0A&repo=zenprocess%2Faigrija"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/deploy-prod.yml
Line: 122-125

Comment:
**AWS credential names differ from `deploy` job**

The `infra-validate` job uses generic secret names (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`) while the `deploy` job uses R2-specific names (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ENDPOINT_URL`) — both pointing at the same `ai-grija-pulumi-state` bucket. This asymmetry was pre-existing and mirrors the same pattern already established in `pr-checks.yml` (lines 102-104), so it's a known configuration choice; however, if these are distinct secret values rather than aliases, validation could be targeting a different backend than production deployment. Worth confirming both secret sets resolve to the same R2 credentials.

```suggestion
          PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
          AWS_ENDPOINT_URL_S3: ${{ secrets.R2_ENDPOINT_URL }}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/deploy-prod.yml
Line: 131

Comment:
**`dev` stack in production validation**

The `stack-name` is now `dev` (matching `Pulumi.dev.yaml`), which aligns with the `deploy` job at line 174. However, the workflow is named "Deploy Production" and previously used `stack-name: production`. If there is no `Pulumi.production.yaml` and `dev` is the only stack, this is correct. Just confirming this is intentional and not accidentally pointing production validation at a non-production stack — the PR description confirms it is, so this is just a heads-up for any future reader.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: deploy-prod.yml..."](https://github.com/zenprocess/aigrija/commit/a5bb62b042e891430e4c40c9ec225950cea7c7f2)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->