### PR TITLE
fix: CI policyPacks path + dep audit flag

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -93,7 +93,7 @@ jobs:
           node-version: '22'
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm audit --audit-level=high
+      - run: pnpm audit --prod
 
   infra-validate:
     name: Infrastructure validation
@@ -130,7 +130,7 @@ jobs:
           command: preview
           stack-name: dev
           work-dir: infra
-          policyPacks: infra/policy
+          policyPacks: policy
         env:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -173,7 +173,7 @@ jobs:
           command: up
           stack-name: dev
           work-dir: infra
-          policyPacks: infra/policy
+          policyPacks: policy
         env:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -109,7 +109,7 @@ jobs:
           command: preview
           stack-name: dev
           work-dir: infra
-          policyPacks: infra/policy
+          policyPacks: policy
         env:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
policyPacks relative to work-dir (infra/) + audit --prod

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two CI issues in both workflow files: corrects the `policyPacks` path from `infra/policy` to `policy` (relative to `work-dir: infra`) and updates the Pulumi R2 backend login URL to include the explicit Cloudflare R2 endpoint. It also introduces a `HAS_PULUMI` job-level env var to avoid direct secret comparisons in `if:` conditions, and changes `pnpm audit --audit-level=high` to `pnpm audit --prod`.

**Key changes:**
- `policyPacks: infra/policy` → `policyPacks: policy` across all three Pulumi action invocations — the correct fix, since `work-dir: infra` already roots resolution inside `infra/`
- Pulumi login URL updated to include the `region=auto&endpoint=` Cloudflare R2 query parameters (previously only `s3://...` with `--secrets-provider passphrase`)
- `HAS_PULUMI` computed env var replaces inline secret comparisons in `if:` conditions — clean pattern, correctly evaluates to `'true'` or `''`
- `pnpm audit --audit-level=high` → `pnpm audit --prod` — changes audit scope to production-only deps but drops the severity threshold, meaning low-severity prod-dep vulns can now fail CI while high-severity dev-dep vulns pass silently
- `stack-name: production` → `stack-name: dev` in the `infra-validate` job of `deploy-prod.yml` — the production workflow's validation gate now previews `dev` stack config instead of `production`, which may miss production-specific configuration issues before deploying

<h3>Confidence Score: 2/5</h3>

- Needs review before merging — the `stack-name` regression silently drops production-stack validation in the deploy pipeline.
- The `policyPacks` path fix and R2 URL update are correct. However, changing `stack-name` from `production` to `dev` in the production workflow's `infra-validate` job is a meaningful regression: the job no longer validates the production Pulumi stack before deploying. Additionally, dropping `--audit-level=high` from the audit command changes CI failure semantics in both directions (stricter for prod deps, silent for dev deps with high vulns). Together these represent two unintended behavior changes in a production deployment workflow.
- `.github/workflows/deploy-prod.yml` — specifically the `stack-name` change in `infra-validate` (line 131) and the `pnpm audit` flag change (line 96).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-prod.yml | Fixes policyPacks path and R2 backend URL; introduces `HAS_PULUMI` env var guard. Two issues: `--audit-level` flag dropped from `pnpm audit`, and `stack-name` changed from `production` to `dev` in infra-validate which may skip production-stack validation before deployment. |
| .github/workflows/pr-checks.yml | Single change: `policyPacks` corrected from `infra/policy` to `policy` (relative to `work-dir: infra`). Correct fix; no new issues introduced beyond the pre-existing redundant `env` block on the warning step. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push to main] --> B{skip_tests?}
    B -- no --> C[typecheck / test / secret-scan / dependency-audit]
    C --> D[infra-validate]
    D --> E{HAS_PULUMI?}
    E -- yes --> F[pulumi login\nR2 endpoint w/ CF account]
    F --> G[pulumi preview\nstack: dev ⚠️ was production\npolicyPacks: policy ✅]
    E -- no --> H[echo warning]
    G --> I[deploy job\npulumi up stack: dev\npolicyPacks: policy ✅]
    H --> I
    B -- yes --> I
    I --> J[wrangler deploy to CF Workers]
    J --> K[smoke-test + health-check]
    K --> L[post-deploy BDD]

    subgraph audit [dependency-audit]
      M[pnpm audit --prod\n⚠️ no --audit-level flag]
    end
    C --> audit
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fdeploy-prod.yml%3A96%0A**%60--audit-level%60%20removed%2C%20dev-dep%20vulns%20no%20longer%20caught**%0A%0AChanging%20from%20%60pnpm%20audit%20--audit-level%3Dhigh%60%20to%20%60pnpm%20audit%20--prod%60%20has%20two%20behaviour%20changes%20that%20partially%20offset%20each%20other%20but%20together%20weaken%20the%20security%20gate%3A%0A%0A1.%20**Scope%20narrowed%20to%20production%20deps%20only**%20%E2%80%94%20dev%20dependencies%20with%20high%2Fcritical%20vulnerabilities%20are%20no%20longer%20audited%20in%20CI.%0A2.%20**No%20%60--audit-level%60%20flag**%20%E2%80%94%20for%20the%20deps%20that%20_are_%20checked%2C%20the%20default%20audit%20level%20is%20%60low%60%2C%20so%20any%20trivial%20vulnerability%20in%20a%20production%20dependency%20will%20now%20fail%20the%20build%20%28potentially%20noisy%29%2C%20while%20before%20only%20%60high%60%2B%20severity%20triggered%20a%20failure.%0A%0AThe%20result%20is%20that%20a%20high-severity%20vulnerability%20in%20a%20devDependency%20%28e.g.%20a%20build%20tool%20or%20test%20runner%29%20would%20pass%20CI%20silently.%20Consider%20combining%20both%20flags%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20run%3A%20pnpm%20audit%20--prod%20--audit-level%3Dhigh%0A%60%60%60%0A%0AOr%2C%20if%20intentionally%20ignoring%20dev-dep%20vulns%20is%20the%20goal%2C%20at%20least%20document%20the%20reasoning%20in%20a%20comment.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fdeploy-prod.yml%3A131%0A**%60stack-name%60%20changed%20to%20%60dev%60%20in%20production%20infra-validate**%0A%0AThe%20%60infra-validate%60%20job%20in%20the%20production%20deploy%20workflow%20now%20previews%20against%20the%20%60dev%60%20stack%20instead%20of%20%60production%60.%20Before%20this%20PR%2C%20there%20was%20an%20intentional%20distinction%3A%20the%20validation%20step%20ran%20%60preview%60%20against%20%60production%60%20while%20the%20actual%20%60deploy%60%20job%20ran%20%60up%60%20against%20%60dev%60.%20Changing%20this%20to%20%60dev%60%20means%20the%20production%20workflow%20no%20longer%20exercises%20the%20production%20stack%20config%20during%20its%20validation%20gate%20%E2%80%94%20production-specific%20Pulumi%20config%2C%20secrets%2C%20or%20resource%20configurations%20won't%20be%20caught%20before%20the%20deploy%20runs.%0A%0AIf%20this%20change%20is%20intentional%20%28e.g.%20the%20%60production%60%20stack%20was%20removed%20or%20renamed%29%2C%20please%20add%20a%20comment%20explaining%20the%20stack%20layout.%20Otherwise%2C%20this%20should%20stay%20as%20%60production%60%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20stack-name%3A%20production%0A%60%60%60%0A%0A&repo=zenprocess%2Faigrija"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/deploy-prod.yml
Line: 96

Comment:
**`--audit-level` removed, dev-dep vulns no longer caught**

Changing from `pnpm audit --audit-level=high` to `pnpm audit --prod` has two behaviour changes that partially offset each other but together weaken the security gate:

1. **Scope narrowed to production deps only** — dev dependencies with high/critical vulnerabilities are no longer audited in CI.
2. **No `--audit-level` flag** — for the deps that _are_ checked, the default audit level is `low`, so any trivial vulnerability in a production dependency will now fail the build (potentially noisy), while before only `high`+ severity triggered a failure.

The result is that a high-severity vulnerability in a devDependency (e.g. a build tool or test runner) would pass CI silently. Consider combining both flags:

```suggestion
      - run: pnpm audit --prod --audit-level=high
```

Or, if intentionally ignoring dev-dep vulns is the goal, at least document the reasoning in a comment.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: .github/workflows/deploy-prod.yml
Line: 131

Comment:
**`stack-name` changed to `dev` in production infra-validate**

The `infra-validate` job in the production deploy workflow now previews against the `dev` stack instead of `production`. Before this PR, there was an intentional distinction: the validation step ran `preview` against `production` while the actual `deploy` job ran `up` against `dev`. Changing this to `dev` means the production workflow no longer exercises the production stack config during its validation gate — production-specific Pulumi config, secrets, or resource configurations won't be caught before the deploy runs.

If this change is intentional (e.g. the `production` stack was removed or renamed), please add a comment explaining the stack layout. Otherwise, this should stay as `production`:

```suggestion
          stack-name: production
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: CI — policyPack..."](https://github.com/zenprocess/aigrija/commit/268d74e429a132131bbad63e2225efd44eb8b35d)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->