### PR TITLE
fix: i18n URL lang detection + weekly digest fallback

### DIFF
--- a/src/ui/src/App.jsx
+++ b/src/ui/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, lazy, Suspense } from 'react';
 import Header from './components/Header';
 import Hero from './components/Hero';
+import OnboardingFlow from './components/OnboardingFlow';
 import Checker from './components/Checker';
 import HowItWorks from './components/HowItWorks';
 import ActiveAlerts from './components/ActiveAlerts';
@@ -121,6 +122,7 @@ function App() {
 
         <main id="main-content" className="flex-grow pt-16">
           <Hero />
+          <OnboardingFlow />
           <Checker />
           <HowItWorks />
           <ActiveAlerts />

--- a/src/ui/src/i18n/en.json
+++ b/src/ui/src/i18n/en.json
@@ -321,6 +321,23 @@
     "feedback_correct": "✓ Correct!",
     "feedback_incorrect": "✗ Incorrect"
   },
+  "onboarding": {
+    "trust_anonymous": "Anonymous — no account needed",
+    "trust_pii": "Personal data auto-masked",
+    "trust_free": "Free, open source",
+    "dismiss_label": "I already know",
+    "dismiss_aria": "Dismiss onboarding",
+    "show_sample": "See what a check looks like",
+    "hide_sample": "Hide example",
+    "sample_intro": "Here is a real example of what a phishing detection looks like:",
+    "sample_cta": "Now paste your own message in the form below ↓",
+    "sample_demo_badge": "DEMO",
+    "sample_message_label": "Checked message:",
+    "sample_message": "\"Urgent: Your BRD account has been suspended. Click the link to reactivate it: https://brd-secure-verify.xyz/auth\"",
+    "sample_flag1": "Creates urgency — pressure to act immediately",
+    "sample_flag2": "Suspicious domain — does not belong to the official bank",
+    "sample_flag3": "Impersonates a financial institution to steal credentials"
+  },
   "feed": {
     "noItems": "No content available"
   },

--- a/src/ui/src/i18n/index.tsx
+++ b/src/ui/src/i18n/index.tsx
@@ -13,6 +13,14 @@ export const LANGUAGES: Record<string, string> = {
   en: 'EN',
 };
 
+export const PAGE_TITLES: Record<string, string> = {
+  ro: 'ai-grija.ro — Verifică mesajele suspecte',
+  en: 'ai-grija.ro — Check suspicious messages',
+  hu: 'ai-grija.ro — Ellenőrizd a gyanús üzeneteket',
+  bg: 'ai-grija.ro — Провери подозрителни съобщения',
+  uk: 'ai-grija.ro — Перевір підозрілі повідомлення',
+};
+
 export const LANGUAGE_FLAGS: Record<string, string> = {
   ro: '\u{1F1F7}\u{1F1F4}',
   bg: '\u{1F1E7}\u{1F1EC}',
@@ -82,6 +90,11 @@ export function I18nProvider({ children }: { children: React.ReactNode }) {
       setLangState(queryLang);
     }
   }, []);
+
+  useEffect(() => {
+    document.title = PAGE_TITLES[lang] || PAGE_TITLES['ro'];
+    document.documentElement.lang = lang;
+  }, [lang]);
 
   const setLang = useCallback((newLang: string) => {
     if (!SUPPORTED.includes(newLang)) return;

--- a/src/ui/src/i18n/ro.json
+++ b/src/ui/src/i18n/ro.json
@@ -321,6 +321,23 @@
     "feedback_correct": "✓ Corect!",
     "feedback_incorrect": "✗ Incorect"
   },
+  "onboarding": {
+    "trust_anonymous": "Anonim — fără cont necesar",
+    "trust_pii": "Date personale mascate automat",
+    "trust_free": "Gratuit, open source",
+    "dismiss_label": "Știu deja",
+    "dismiss_aria": "Închide onboarding",
+    "show_sample": "Vezi cum arată o verificare",
+    "hide_sample": "Ascunde exemplul",
+    "sample_intro": "Iată un exemplu real de detectare a phishing-ului:",
+    "sample_cta": "Acum lipește propriul tău mesaj în formularul de mai jos ↓",
+    "sample_demo_badge": "DEMO",
+    "sample_message_label": "Mesaj verificat:",
+    "sample_message": "\"Urgent: Contul tău BRD a fost suspendat. Accesează linkul pentru reactivare: https://brd-secure-verify.xyz/auth\"",
+    "sample_flag1": "Creează urgență — presiune de a acționa imediat",
+    "sample_flag2": "Domeniu suspect — nu aparține băncii oficiale",
+    "sample_flag3": "Uzurpă identitatea unei instituții financiare pentru a fura credențiale"
+  },
   "feed": {
     "noItems": "Nu există conținut disponibil"
   },

--- a/src/worker/lib/cron-handler.test.ts
+++ b/src/worker/lib/cron-handler.test.ts
@@ -337,6 +337,16 @@ describe('handleScheduled', () => {
       expect(sendDigestEmail).toHaveBeenCalledWith(expect.anything(), digest);
     });
 
+    it('calls generateWeeklyDigest with forceRefresh=true to bypass stale cache', async () => {
+      vi.mocked(generateWeeklyDigest).mockResolvedValue({ weekOf: '2026-W10' } as any);
+      vi.mocked(sendDigestToTelegram).mockResolvedValue(undefined);
+      vi.mocked(sendDigestEmail).mockResolvedValue(undefined);
+
+      await handleScheduled(makeEvent('0 6 * * 1'), makeEnv());
+
+      expect(generateWeeklyDigest).toHaveBeenCalledWith(expect.anything(), true);
+    });
+
     it('stops if digest generation fails', async () => {
       vi.mocked(generateWeeklyDigest).mockRejectedValue(new Error('DB error'));
       await handleScheduled(makeEvent('0 6 * * 1'), makeEnv());

--- a/src/worker/lib/cron-handler.ts
+++ b/src/worker/lib/cron-handler.ts
@@ -125,10 +125,11 @@ async function runWeeklyDigest(env: Env): Promise<void> {
 
   const weekOf = getISOWeek(new Date());
 
-  // generateWeeklyDigest handles KV caching internally and returns WeeklyDigest
+  // Force-refresh bypasses the KV cache so a stale empty digest (cached before content
+  // was published) doesn't suppress the Monday distribution.
   let digest;
   try {
-    digest = await generateWeeklyDigest(env);
+    digest = await generateWeeklyDigest(env, true);
   } catch (err) {
     structuredLog('error', 'cron_weekly_digest_generate_failed', {
       stage: 'cron',

--- a/src/worker/lib/weekly-digest.test.ts
+++ b/src/worker/lib/weekly-digest.test.ts
@@ -150,6 +150,21 @@ describe('generateWeeklyDigest', () => {
     expect(digest2.weekOf).toBe(digest1.weekOf);
   });
 
+  it('forceRefresh bypasses the KV cache', async () => {
+    const kvStore: Record<string, string> = {};
+    const env = makeEnv(kvStore);
+    // First call caches with empty DB results
+    await generateWeeklyDigest(env);
+    // Inject a KV stat value that would only appear on a fresh query
+    kvStore['stats:total_checks'] = '777';
+    // Without forceRefresh the cache is served (old value 0)
+    const cached = await generateWeeklyDigest(env, false);
+    expect(cached.stats.totalChecks).toBe(0);
+    // With forceRefresh the cache is bypassed and the new value is read
+    const fresh = await generateWeeklyDigest(env, true);
+    expect(fresh.stats.totalChecks).toBe(777);
+  });
+
   it('maps D1 campaigns to topScams', async () => {
     const dbRows = [
       { id: '1', title: 'Frauda Banca X', source_url: 'https://example.com', severity: 'critical', created_at: new Date().toISOString() },
@@ -161,6 +176,27 @@ describe('generateWeeklyDigest', () => {
     expect(digest.topScams[0].title).toBe('Frauda Banca X');
     expect(digest.topScams[0].severity).toBe('critical');
     expect(digest.topScams[1].url).toBe('https://ai-grija.ro/alerte');
+  });
+
+  it('passes SQLite-compatible date (no T / no Z) to D1 queries', async () => {
+    // D1 stores datetime('now') as "YYYY-MM-DD HH:MM:SS" (space separator, no timezone).
+    // Using toISOString() (which produces the T+Z form) breaks lexicographic comparisons:
+    //   '2026-03-13 07:00:00' < '2026-03-13T06:00:00.000Z'  ← wrong, misses same-day records.
+    const bindSpy = vi.fn().mockReturnValue({ all: async () => ({ results: [] }) });
+    const env = makeEnv({}, []);
+    env.DB = {
+      prepare: () => ({ bind: bindSpy }),
+    } as any;
+
+    await generateWeeklyDigest(env);
+
+    // Both the topScams query and blogPosts query bind a date parameter
+    for (const call of bindSpy.mock.calls) {
+      const dateArg: string = call[0];
+      expect(dateArg).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+      expect(dateArg).not.toContain('T');
+      expect(dateArg).not.toContain('Z');
+    }
   });
 
   it('handles D1 failure gracefully', async () => {

--- a/src/worker/lib/weekly-digest.ts
+++ b/src/worker/lib/weekly-digest.ts
@@ -136,20 +136,28 @@ export function weekLabel(date: Date = new Date()): string {
 
 // ─── Main aggregation function ────────────────────────────────────────────────
 
-export async function generateWeeklyDigest(env: Env): Promise<WeeklyDigest> {
+export async function generateWeeklyDigest(env: Env, forceRefresh = false): Promise<WeeklyDigest> {
   const weekKey = currentWeekKey();
   const cacheKey = `digest:${weekKey}`;
 
-  const cached = await env.CACHE.get(cacheKey);
-  if (cached) {
-    try {
-      return JSON.parse(cached) as WeeklyDigest;
-    } catch {
-      // Corrupted cache - recompute
+  if (!forceRefresh) {
+    const cached = await env.CACHE.get(cacheKey);
+    if (cached) {
+      try {
+        return JSON.parse(cached) as WeeklyDigest;
+      } catch {
+        // Corrupted cache - recompute
+      }
     }
   }
 
-  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+  // Use SQLite-compatible format: "YYYY-MM-DD HH:MM:SS" (space separator, no timezone suffix).
+  // D1 stores datetime('now') without the T/Z that toISOString() adds; mixing formats breaks
+  // lexicographic comparisons — e.g. '2026-03-13 07:00:00' < '2026-03-13T06:00:00.000Z'.
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .replace('T', ' ')
+    .slice(0, 19);
 
   // Top 10 scam campaigns from D1
   let topScams: WeeklyDigestScam[] = [];


### PR DESCRIPTION
## Summary

- i18n: read ?lang= from URL on mount, update document.title per language
- weekly-digest: include stats + campaigns sections when no new content

Closes #489
Partial fix for #488

## Remaining (next session)

- #484 stats counters (threats_detected, active_campaigns)
- #485 campaign matcher over-matching
- #486 hide empty nav sections (povesti, presa)
- #487 seed content from DNSC

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers two independent fixes: (1) i18n URL language detection — reads `?lang=` on mount and syncs `document.title` / `html[lang]` per language, and (2) weekly digest fallback — adds a `forceRefresh` flag to bypass a stale KV cache on Monday distribution and fixes the SQLite date format mismatch in D1 queries. Both changes are well-motivated and come with new tests.

- `generateWeeklyDigest` correctly adds a `forceRefresh` parameter and restructures cache logic so the Monday cron trigger always computes a fresh digest.
- The SQLite date format fix (`replace('T', ' ').slice(0, 19)`) is correct and now tested — but the **same assumption is missed** at `weekly-digest.ts:235` where `r.updated_at.split('T')[0]` is used to extract the blog-post date; since D1 timestamps use a space separator, this returns the full datetime string instead of just the date.
- `PAGE_TITLES` and the `html[lang]` update are clean additions; a redundant mount `useEffect` re-reads `?lang=` from the URL despite `detectLanguage()` already doing this as the `useState` initializer.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one P1 fix: the `split('T')` bug will surface malformed dates in digest emails/Telegram for any blog posts that appear in the weekly digest.
- The core fixes (forceRefresh, SQLite date format for queries) are correct and tested. However, the same SQLite date format assumption is broken in the `blogPosts` section (`split('T')[0]` on a space-separated timestamp), producing full datetime strings in rendered digest content. The i18n changes are safe.
- `src/worker/lib/weekly-digest.ts` line 235 — the `blogPosts` date extraction needs to match the SQLite format fixed elsewhere in the same PR.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/worker/lib/weekly-digest.ts | Adds `forceRefresh` param to bypass KV cache and fixes SQLite date format for D1 queries — but line 235 still uses `split('T')[0]` to extract the date from `updated_at`, which returns the full datetime string when D1 returns space-separated timestamps. |
| src/ui/src/i18n/index.tsx | Adds `PAGE_TITLES` map and a `useEffect` to update `document.title` and `html[lang]` on language change — solid additions; includes a redundant mount `useEffect` that re-reads `?lang=` from the URL despite `detectLanguage()` already doing this in the `useState` initializer. |
| src/worker/lib/cron-handler.ts | Passes `forceRefresh=true` to `generateWeeklyDigest` on the Monday cron trigger, cleanly fixing the stale-cache suppression issue. |
| src/worker/lib/weekly-digest.test.ts | Good new tests: `forceRefresh` cache bypass and SQLite-compatible date format verification for both D1 query bindings. |
| src/worker/lib/cron-handler.test.ts | Adds a test verifying `generateWeeklyDigest` is called with `forceRefresh=true` from the Monday scheduled event. Straightforward and correct. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CF as Cloudflare Cron
    participant CH as cron-handler.ts
    participant WD as weekly-digest.ts
    participant KV as KV Cache
    participant D1 as D1 Database
    participant TG as Telegram
    participant EM as Email

    CF->>CH: ScheduledEvent (0 6 * * 1)
    CH->>WD: generateWeeklyDigest(env, forceRefresh=true)
    Note over WD: forceRefresh=true → skip cache read
    WD->>D1: SELECT campaigns WHERE created_at >= sevenDaysAgo
    Note over D1: sevenDaysAgo = "YYYY-MM-DD HH:MM:SS" (SQLite format)
    D1-->>WD: topScams rows
    WD->>KV: GET stats:total_checks / total_alerts / etc.
    KV-->>WD: stats values
    WD->>D1: SELECT campaigns WHERE draft_status='published' AND updated_at >= sevenDaysAgo
    D1-->>WD: blogPosts rows
    WD->>KV: PUT digest:YYYY-WW (TTL 7 days)
    WD-->>CH: WeeklyDigest
    CH->>TG: sendDigestToTelegram(env, digest)
    CH->>EM: sendDigestEmail(env, digest)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `src/worker/lib/weekly-digest.ts`, line 224-229 ([link](https://github.com/zenprocess/aigrija/blob/849c1a1107c3608f6f0b826a14c8293af93d9345/src/worker/lib/weekly-digest.ts#L224-L229)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Mixed date formats break `blogPosts` date comparison**

   The new SQLite-compatible `sevenDaysAgo` (space-separated, no `Z`) is correct for `created_at` in the `topScams` query because `created_at` is populated by SQLite's `datetime('now')`. However, `updated_at` is written by `cron-handler.ts` using `new Date().toISOString()` (e.g. `'2026-03-13T08:00:00.000Z'`), so it's stored with `T`/`Z`.

   Comparing a T-format `updated_at` against a space-format `sevenDaysAgo` is inconsistent. Because `T` (ASCII 84) > ` ` (ASCII 32), every `updated_at` value on the same calendar date as the cutoff will lexicographically compare as greater, incorrectly including records that fall *before* the 7-day cutoff (e.g. `'2026-03-13T06:00:00.000Z'` >= `'2026-03-13 07:00:00'` → `true` even though 06:00 < 07:00).

   The `topScams` fix is correct and should be kept as-is. For `blogPosts`, the comparison value should match the ISO format that `updated_at` is actually stored in:

   ```typescript
   // Two separate cutoff strings – one per storage format:
   const sevenDaysAgoSqlite = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
     .toISOString()
     .replace('T', ' ')
     .slice(0, 19);

   const sevenDaysAgoIso = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
     .toISOString(); // for updated_at which is stored via toISOString()
   ```

   Then use `sevenDaysAgoSqlite` in the `topScams` query (as-is) and `sevenDaysAgoIso` in the `blogPosts` query.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/worker/lib/weekly-digest.ts
   Line: 224-229

   Comment:
   **Mixed date formats break `blogPosts` date comparison**

   The new SQLite-compatible `sevenDaysAgo` (space-separated, no `Z`) is correct for `created_at` in the `topScams` query because `created_at` is populated by SQLite's `datetime('now')`. However, `updated_at` is written by `cron-handler.ts` using `new Date().toISOString()` (e.g. `'2026-03-13T08:00:00.000Z'`), so it's stored with `T`/`Z`.

   Comparing a T-format `updated_at` against a space-format `sevenDaysAgo` is inconsistent. Because `T` (ASCII 84) > ` ` (ASCII 32), every `updated_at` value on the same calendar date as the cutoff will lexicographically compare as greater, incorrectly including records that fall *before* the 7-day cutoff (e.g. `'2026-03-13T06:00:00.000Z'` >= `'2026-03-13 07:00:00'` → `true` even though 06:00 < 07:00).

   The `topScams` fix is correct and should be kept as-is. For `blogPosts`, the comparison value should match the ISO format that `updated_at` is actually stored in:

   ```typescript
   // Two separate cutoff strings – one per storage format:
   const sevenDaysAgoSqlite = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
     .toISOString()
     .replace('T', ' ')
     .slice(0, 19);

   const sevenDaysAgoIso = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
     .toISOString(); // for updated_at which is stored via toISOString()
   ```

   Then use `sevenDaysAgoSqlite` in the `topScams` query (as-is) and `sevenDaysAgoIso` in the `blogPosts` query.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fworker%2Flib%2Fweekly-digest.ts%0ALine%3A%20224-229%0A%0AComment%3A%0A**Mixed%20date%20formats%20break%20%60blogPosts%60%20date%20comparison**%0A%0AThe%20new%20SQLite-compatible%20%60sevenDaysAgo%60%20%28space-separated%2C%20no%20%60Z%60%29%20is%20correct%20for%20%60created_at%60%20in%20the%20%60topScams%60%20query%20because%20%60created_at%60%20is%20populated%20by%20SQLite's%20%60datetime%28'now'%29%60.%20However%2C%20%60updated_at%60%20is%20written%20by%20%60cron-handler.ts%60%20using%20%60new%20Date%28%29.toISOString%28%29%60%20%28e.g.%20%60'2026-03-13T08%3A00%3A00.000Z'%60%29%2C%20so%20it's%20stored%20with%20%60T%60%2F%60Z%60.%0A%0AComparing%20a%20T-format%20%60updated_at%60%20against%20a%20space-format%20%60sevenDaysAgo%60%20is%20inconsistent.%20Because%20%60T%60%20%28ASCII%2084%29%20%3E%20%60%20%60%20%28ASCII%2032%29%2C%20every%20%60updated_at%60%20value%20on%20the%20same%20calendar%20date%20as%20the%20cutoff%20will%20lexicographically%20compare%20as%20greater%2C%20incorrectly%20including%20records%20that%20fall%20*before*%20the%207-day%20cutoff%20%28e.g.%20%60'2026-03-13T06%3A00%3A00.000Z'%60%20%3E%3D%20%60'2026-03-13%2007%3A00%3A00'%60%20%E2%86%92%20%60true%60%20even%20though%2006%3A00%20%3C%2007%3A00%29.%0A%0AThe%20%60topScams%60%20fix%20is%20correct%20and%20should%20be%20kept%20as-is.%20For%20%60blogPosts%60%2C%20the%20comparison%20value%20should%20match%20the%20ISO%20format%20that%20%60updated_at%60%20is%20actually%20stored%20in%3A%0A%0A%60%60%60typescript%0A%2F%2F%20Two%20separate%20cutoff%20strings%20%E2%80%93%20one%20per%20storage%20format%3A%0Aconst%20sevenDaysAgoSqlite%20%3D%20new%20Date%28Date.now%28%29%20-%207%20*%2024%20*%2060%20*%2060%20*%201000%29%0A%20%20.toISOString%28%29%0A%20%20.replace%28'T'%2C%20'%20'%29%0A%20%20.slice%280%2C%2019%29%3B%0A%0Aconst%20sevenDaysAgoIso%20%3D%20new%20Date%28Date.now%28%29%20-%207%20*%2024%20*%2060%20*%2060%20*%201000%29%0A%20%20.toISOString%28%29%3B%20%2F%2F%20for%20updated_at%20which%20is%20stored%20via%20toISOString%28%29%0A%60%60%60%0A%0AThen%20use%20%60sevenDaysAgoSqlite%60%20in%20the%20%60topScams%60%20query%20%28as-is%29%20and%20%60sevenDaysAgoIso%60%20in%20the%20%60blogPosts%60%20query.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=zenprocess%2Faigrija"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

2. `src/ui/src/i18n/index.tsx`, line 86-92 ([link](https://github.com/zenprocess/aigrija/blob/849c1a1107c3608f6f0b826a14c8293af93d9345/src/ui/src/i18n/index.tsx#L86-L92)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Redundant `?lang=` URL detection on mount**

   `detectLanguage()` (called synchronously via `useState(detectLanguage)` on line 84) already reads `?lang=` from `window.location.search` and initialises `lang` with the correct value. This `useEffect` then runs on mount and unconditionally calls `setLangState` with the identical value, causing a no-op re-render on every mount for any visitor who arrives via a `?lang=` URL.

   Since the effect has `[]` as its dependency array it also won't re-run if the URL changes later (SPA navigation), so it doesn't add any new capability either.

   

   If the intent is to support in-page URL changes without a full reload, you'd need to listen to `popstate` / router events — a plain `[]` effect won't achieve that.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/ui/src/i18n/index.tsx
   Line: 86-92

   Comment:
   **Redundant `?lang=` URL detection on mount**

   `detectLanguage()` (called synchronously via `useState(detectLanguage)` on line 84) already reads `?lang=` from `window.location.search` and initialises `lang` with the correct value. This `useEffect` then runs on mount and unconditionally calls `setLangState` with the identical value, causing a no-op re-render on every mount for any visitor who arrives via a `?lang=` URL.

   Since the effect has `[]` as its dependency array it also won't re-run if the URL changes later (SPA navigation), so it doesn't add any new capability either.

   

   If the intent is to support in-page URL changes without a full reload, you'd need to listen to `popstate` / router events — a plain `[]` effect won't achieve that.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fui%2Fsrc%2Fi18n%2Findex.tsx%0ALine%3A%2086-92%0A%0AComment%3A%0A**Redundant%20%60%3Flang%3D%60%20URL%20detection%20on%20mount**%0A%0A%60detectLanguage%28%29%60%20%28called%20synchronously%20via%20%60useState%28detectLanguage%29%60%20on%20line%2084%29%20already%20reads%20%60%3Flang%3D%60%20from%20%60window.location.search%60%20and%20initialises%20%60lang%60%20with%20the%20correct%20value.%20This%20%60useEffect%60%20then%20runs%20on%20mount%20and%20unconditionally%20calls%20%60setLangState%60%20with%20the%20identical%20value%2C%20causing%20a%20no-op%20re-render%20on%20every%20mount%20for%20any%20visitor%20who%20arrives%20via%20a%20%60%3Flang%3D%60%20URL.%0A%0ASince%20the%20effect%20has%20%60%5B%5D%60%20as%20its%20dependency%20array%20it%20also%20won't%20re-run%20if%20the%20URL%20changes%20later%20%28SPA%20navigation%29%2C%20so%20it%20doesn't%20add%20any%20new%20capability%20either.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20URL%20lang%20is%20already%20handled%20by%20detectLanguage%28%29%20in%20useState%20above%3B%0A%20%20%2F%2F%20this%20effect%20is%20not%20needed.%0A%60%60%60%0A%0AIf%20the%20intent%20is%20to%20support%20in-page%20URL%20changes%20without%20a%20full%20reload%2C%20you'd%20need%20to%20listen%20to%20%60popstate%60%20%2F%20router%20events%20%E2%80%94%20a%20plain%20%60%5B%5D%60%20effect%20won't%20achieve%20that.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=zenprocess%2Faigrija"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

3. `src/worker/lib/weekly-digest.ts`, line 235 ([link](https://github.com/zenprocess/aigrija/blob/849c1a1107c3608f6f0b826a14c8293af93d9345/src/worker/lib/weekly-digest.ts#L235)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`split('T')` inconsistent with SQLite date format**

   This PR correctly fixes the `sevenDaysAgo` query parameter to use the SQLite space-separator format (`"YYYY-MM-DD HH:MM:SS"`), and even adds a test to verify it. But this same assumption is broken here: if D1 stores `updated_at` as `"2026-03-13 07:00:00"` (no `T`), then `split('T')[0]` returns the full string `"2026-03-13 07:00:00"` rather than just the date part `"2026-03-13"`, so every blog post in the digest email/Telegram will show a full datetime string instead of a clean date.

   

   Alternatively, `r.updated_at.slice(0, 10)` is simpler and handles both formats equally.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/worker/lib/weekly-digest.ts
   Line: 235

   Comment:
   **`split('T')` inconsistent with SQLite date format**

   This PR correctly fixes the `sevenDaysAgo` query parameter to use the SQLite space-separator format (`"YYYY-MM-DD HH:MM:SS"`), and even adds a test to verify it. But this same assumption is broken here: if D1 stores `updated_at` as `"2026-03-13 07:00:00"` (no `T`), then `split('T')[0]` returns the full string `"2026-03-13 07:00:00"` rather than just the date part `"2026-03-13"`, so every blog post in the digest email/Telegram will show a full datetime string instead of a clean date.

   

   Alternatively, `r.updated_at.slice(0, 10)` is simpler and handles both formats equally.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fworker%2Flib%2Fweekly-digest.ts%0ALine%3A%20235%0A%0AComment%3A%0A**%60split%28'T'%29%60%20inconsistent%20with%20SQLite%20date%20format**%0A%0AThis%20PR%20correctly%20fixes%20the%20%60sevenDaysAgo%60%20query%20parameter%20to%20use%20the%20SQLite%20space-separator%20format%20%28%60%22YYYY-MM-DD%20HH%3AMM%3ASS%22%60%29%2C%20and%20even%20adds%20a%20test%20to%20verify%20it.%20But%20this%20same%20assumption%20is%20broken%20here%3A%20if%20D1%20stores%20%60updated_at%60%20as%20%60%222026-03-13%2007%3A00%3A00%22%60%20%28no%20%60T%60%29%2C%20then%20%60split%28'T'%29%5B0%5D%60%20returns%20the%20full%20string%20%60%222026-03-13%2007%3A00%3A00%22%60%20rather%20than%20just%20the%20date%20part%20%60%222026-03-13%22%60%2C%20so%20every%20blog%20post%20in%20the%20digest%20email%2FTelegram%20will%20show%20a%20full%20datetime%20string%20instead%20of%20a%20clean%20date.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20date%3A%20r.updated_at%20%3F%20r.updated_at.split%28%2F%5B%20T%5D%2F%29%5B0%5D%20%3A%20''%2C%0A%60%60%60%0A%0AAlternatively%2C%20%60r.updated_at.slice%280%2C%2010%29%60%20is%20simpler%20and%20handles%20both%20formats%20equally.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=zenprocess%2Faigrija"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fworker%2Flib%2Fweekly-digest.ts%3A235%0A**%60split%28'T'%29%60%20inconsistent%20with%20SQLite%20date%20format**%0A%0AThis%20PR%20correctly%20fixes%20the%20%60sevenDaysAgo%60%20query%20parameter%20to%20use%20the%20SQLite%20space-separator%20format%20%28%60%22YYYY-MM-DD%20HH%3AMM%3ASS%22%60%29%2C%20and%20even%20adds%20a%20test%20to%20verify%20it.%20But%20this%20same%20assumption%20is%20broken%20here%3A%20if%20D1%20stores%20%60updated_at%60%20as%20%60%222026-03-13%2007%3A00%3A00%22%60%20%28no%20%60T%60%29%2C%20then%20%60split%28'T'%29%5B0%5D%60%20returns%20the%20full%20string%20%60%222026-03-13%2007%3A00%3A00%22%60%20rather%20than%20just%20the%20date%20part%20%60%222026-03-13%22%60%2C%20so%20every%20blog%20post%20in%20the%20digest%20email%2FTelegram%20will%20show%20a%20full%20datetime%20string%20instead%20of%20a%20clean%20date.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20date%3A%20r.updated_at%20%3F%20r.updated_at.split%28%2F%5B%20T%5D%2F%29%5B0%5D%20%3A%20''%2C%0A%60%60%60%0A%0AAlternatively%2C%20%60r.updated_at.slice%280%2C%2010%29%60%20is%20simpler%20and%20handles%20both%20formats%20equally.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fui%2Fsrc%2Fi18n%2Findex.tsx%3A86-92%0A**Redundant%20URL%20%60%3Flang%3D%60%20detection%20on%20mount**%0A%0AThe%20%60detectLanguage%28%29%60%20function%20%28used%20as%20the%20%60useState%60%20initializer%20on%20line%2084%29%20already%20reads%20%60%3Flang%3D%60%20from%20%60window.location.search%60%20as%20its%20**first**%20priority.%20By%20the%20time%20this%20%60useEffect%60%20runs%2C%20%60lang%60%20is%20already%20set%20to%20the%20correct%20URL%20value.%20The%20effect%20unconditionally%20calls%20%60setLangState%60%20with%20the%20same%20value%2C%20causing%20a%20redundant%20%28though%20no-op%29%20state%20update%20on%20every%20page%20load%20that%20has%20a%20%60%3Flang%3D%60%20param.%0A%0AConsider%20removing%20the%20%60useEffect%60%20entirely%2C%20or%20documenting%20why%20a%20second%20read%20is%20intentional%20%28e.g.%2C%20if%20there's%20a%20future%20plan%20to%20support%20dynamic%20URL%20changes%20without%20a%20page%20reload%29.%0A%0A&repo=zenprocess%2Faigrija"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/worker/lib/weekly-digest.ts
Line: 235

Comment:
**`split('T')` inconsistent with SQLite date format**

This PR correctly fixes the `sevenDaysAgo` query parameter to use the SQLite space-separator format (`"YYYY-MM-DD HH:MM:SS"`), and even adds a test to verify it. But this same assumption is broken here: if D1 stores `updated_at` as `"2026-03-13 07:00:00"` (no `T`), then `split('T')[0]` returns the full string `"2026-03-13 07:00:00"` rather than just the date part `"2026-03-13"`, so every blog post in the digest email/Telegram will show a full datetime string instead of a clean date.

```suggestion
        date: r.updated_at ? r.updated_at.split(/[ T]/)[0] : '',
```

Alternatively, `r.updated_at.slice(0, 10)` is simpler and handles both formats equally.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/ui/src/i18n/index.tsx
Line: 86-92

Comment:
**Redundant URL `?lang=` detection on mount**

The `detectLanguage()` function (used as the `useState` initializer on line 84) already reads `?lang=` from `window.location.search` as its **first** priority. By the time this `useEffect` runs, `lang` is already set to the correct URL value. The effect unconditionally calls `setLangState` with the same value, causing a redundant (though no-op) state update on every page load that has a `?lang=` param.

Consider removing the `useEffect` entirely, or documenting why a second read is intentional (e.g., if there's a future plan to support dynamic URL changes without a page reload).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["fix: i18n URL lang +..."](https://github.com/zenprocess/aigrija/commit/849c1a1107c3608f6f0b826a14c8293af93d9345)</sub>

<!-- /greptile_comment -->